### PR TITLE
docs: add canonical 220-pattern catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ flowchart TB
   G[Candidate] --> H[Dual post-rewrite gate]
 ```
 
-Read [the thesis](docs/THESIS.md), [architecture](docs/ARCHITECTURE.md), [VoiceDNA reference](docs/VOICE-DNA.md), [pattern taxonomy](docs/PATTERN-TAXONOMY.md), and [benchmark policy](docs/BENCHMARKS.md) before extending the gate.
+Read [the thesis](docs/THESIS.md), [architecture](docs/ARCHITECTURE.md), [VoiceDNA reference](docs/VOICE-DNA.md), the [full 220-pattern editorial catalog](docs/patterns/AI-WRITING-PATTERNS-1-220.md), [pattern taxonomy](docs/PATTERN-TAXONOMY.md), and [benchmark policy](docs/BENCHMARKS.md) before extending the gate.
 
 ## Privacy and data rights
 

--- a/docs/PATTERN-TAXONOMY.md
+++ b/docs/PATTERN-TAXONOMY.md
@@ -1,5 +1,7 @@
 # AI Editor pattern taxonomy
 
-The initial public ruleset is intentionally small and reviewed. It covers generic AI vocabulary, formulaic connectors, hedging, binary persuasion templates, manufactured revelation, dramatic punctuation, question hooks, and abstract-noun clusters.
+The complete owner-authored [220-pattern editorial catalog](patterns/AI-WRITING-PATTERNS-1-220.md) is the canonical source of truth. It preserves the original order, each pattern's mechanism, spotting test, ugly escalation, and selective legitimate exceptions. It is an editorial reference, not an authorship detector.
 
-Each rule exposes a stable ID, regex, severity, explanation, and repair direction through `holdyourvoice patterns`. The original product has multiple overlapping rule implementations and an unverified "220+" count. This repository will not invent or miscount a taxonomy: new rules are added only after deduplication, public provenance review, counterexamples, and tests.
+The initial automated ruleset is intentionally smaller and reviewed. It covers generic AI vocabulary, formulaic connectors, hedging, binary persuasion templates, manufactured revelation, dramatic punctuation, question hooks, and abstract-noun clusters.
+
+Each executable rule exposes a stable ID, regex, severity, explanation, and repair direction through `holdyourvoice patterns`. A catalog entry becomes executable only after deduplication, public provenance review, counterexamples, and tests; the catalog is not silently treated as 220 unvalidated regexes.

--- a/docs/patterns/AI-WRITING-PATTERNS-1-220.md
+++ b/docs/patterns/AI-WRITING-PATTERNS-1-220.md
@@ -1,0 +1,2679 @@
+# AI Writing Patterns: The good, bad and ugly
+
+> Canonical editorial catalog imported from the owner-maintained Notion page on 2026-08-04.
+>
+> This is an editorial reference, not an AI-authorship detector. The automated AI Editor ruleset remains deliberately smaller until each rule has an explicit detector, counterexamples, and tests.
+
+# How to use this guide
+<callout icon="⚠️" color="yellow_bg">
+	**These patterns are editorial signals, not proof of AI authorship.** Human writers use them. AI can avoid them. Mixed human–AI drafts blur the boundary further. Use this guide to inspect and improve writing, never to accuse a writer or determine authorship from style alone.
+</callout>
+One phrase proves nothing. A cluster can justify a closer edit, comparison with the writer’s established work, or a conversation about process. It still does not prove that AI produced the passage. The useful question is: **What is this pattern doing to the writing?**
+Detection research gives strong reasons for that restraint. OpenAI withdrew its own classifier after reporting low accuracy. NIST describes text detection as generator-, prompt-, domain-, and editing-dependent. Peer-reviewed studies show false positives, false negatives, performance loss after paraphrasing, and serious bias against non-native English writers. Human judgment also leans on cues that are easy to manipulate.
+At the same time, large corpus studies have found measurable vocabulary shifts after widespread LLM adoption. Words such as *delve*, *intricate*, *pivotal*, *underscores*, and *comprehensive* rose sharply in biomedical abstracts. That is useful population-level evidence. It cannot identify the author of one sentence.
+The “why AI may reach for it” notes below are editorial hypotheses about common generation shortcuts. They are not claims about a model’s hidden reasoning. The research supports recurring vocabulary, vagueness, formulaic structure, and detector limits at a group level; it does not establish a separate causal mechanism for each phrase.
+## The five-part spotting test
+1. **Repetition:** Does the same device appear again and again?
+2. **Clustering:** Do several patterns stack inside one paragraph?
+3. **Context mismatch:** Does the language sound grander, friendlier, safer, or more balanced than the situation requires?
+4. **Low specificity:** Could the sentence fit hundreds of unrelated subjects?
+5. **Reader value:** Does the structure help the reader find, understand, compare, decide, or act?
+## Legitimate exceptions
+Some patterns remain useful when they serve a clear function:
+- **Necessary:** A safety, legal, ethical, evidentiary, or disclosure requirement.
+- **Functional:** A structure that improves sequence, comparison, scanning, or retrieval.
+- **Audience-serving:** A plain-language explanation for a defined audience.
+- **Genre-required:** A convention required by a journal, report, application, instruction, or regulated format.
+- **Deliberate style:** Rhythm, repetition, or imagery used consciously and sparingly.
+Each ugly version turns the construction into a miniature paragraph and then pushes it past usefulness. The escalation is deliberate: it shows how a phrase that looks harmless once can flatten a paragraph when the writer keeps reaching for it.
+Exceptions are deliberately selective. When an entry has one, the guide also shows a concrete good use that meets the stated conditions. Entries without a meaningful exception do not get a ceremonial defense.
+Official plain-language guidance supports short sentences, meaningful headings, bullets for equal-status items, and numbered lists for sequences. Purdue’s writing guidance supports transitions when they name a real logical relationship. The FTC supports clear, conspicuous disclosures beside the claims they qualify. The problem is not the mere existence of a device. It is automatic, generic, repetitive, or misleading use.
+## Fast navigation
+- Use the table of contents to jump to a 20-pattern range.
+- Search the page for an exact phrase, pattern name, or pattern number.
+- Read the family note first when several nearby entries share the same underlying mechanism.
+<table_of_contents/>
+# Pattern families
+## Caveats, hedges, and safety language
+Models are trained to avoid unsupported certainty and unsafe advice, so they often reach for reusable caveats. The caveat becomes a problem when it is generic, detached from the claim, or used instead of stating the actual limitation.
+Check whether the qualification names a precise risk, boundary, audience, or uncertainty. Generic protection language that could follow any claim is the stronger tell.
+**Cross-domain examples:**
+- Marketing: “It is worth noting that individual results may vary.”
+- Email: “Keep in mind that the date could still change.”
+- Social: “Important note: this is not financial advice.”
+- Essay: “It should be noted that the sample is relatively small.”
+- Workplace: “That said, each team may need a different approach.”
+## Mechanical structure and polished rhythm
+Models maintain coherence by arranging ideas into regular lists, mirrored clauses, even sentence lengths, and explicit labels. That organization can help, but repeated symmetry often reveals that the container was chosen before the substance.
+Inspect the count, order, and rhythm. If every idea arrives in the same-sized package, or prose was forced into three equal parts without a real sequence, the structure is mechanical.
+**Cross-domain examples:**
+- Marketing: “Three pillars. Three tactics. Three wins.”
+- Email: “First, review. Second, approve. Third, celebrate.”
+- Social: “One idea. One post. One breakthrough.”
+- Essay: “Firstly, access matters. Secondly, quality matters. Thirdly, outcomes matter.”
+- Workplace: “Plan. Execute. Measure. Repeat.”
+## Stock metaphors and borrowed imagery
+A familiar metaphor lets a model make an abstract idea feel vivid without supplying a mechanism. Popular journeys, landscapes, engines, stars, oceans, and building frames are statistically safe and easy to continue.
+Name the literal claim underneath the image. If the metaphor adds no usable relationship, mixes with another image, or could describe almost any subject, it is decorative.
+**Cross-domain examples:**
+- Marketing: “Your brand is the North Star of your growth journey.”
+- Email: “This message is a bridge to a brighter partnership.”
+- Social: “Stop shouting into the void and ride the wave.”
+- Essay: “Education is the lighthouse guiding society through turbulent waters.”
+- Workplace: “The roadmap is our compass through the project landscape.”
+## Binary reframing and manufactured balance
+Contrast creates instant momentum and the appearance of judgment. A model can make a familiar point feel sharper by opposing two neat halves, even when reality is additive, uncertain, or multi-causal.
+Test the opposition. Ask whether both halves can be true, whether the evidence rules one side out, and whether the symmetry is stronger than the reasoning.
+**Cross-domain examples:**
+- Marketing: “It is not more traffic you need; it is more trust.”
+- Email: “On one hand, we can ship now; on the other, we can wait.”
+- Social: “The point is not more followers. It is better followers.”
+- Essay: “The issue is not technology itself but society’s response to it.”
+- Workplace: “The hard part is not the deadline; it is alignment.”
+## Transitions, summaries, and procedural framing
+Models use explicit transitions to keep long outputs locally coherent and visibly helpful. The labels become filler when they announce a move that headings, order, or the next sentence already make obvious.
+Remove the signpost and reread the passage. Keep it only if it clarifies sequence, logic, audience, or retrieval. Repeated paragraph-opening transitions are a stronger signal than one necessary cue.
+**Cross-domain examples:**
+- Marketing: “Let’s break down the three steps to stronger conversion.”
+- Email: “To recap, please review, comment, and approve.”
+- Social: “Here are the key takeaways from my morning routine.”
+- Essay: “In conclusion, the evidence highlights several important considerations.”
+- Workplace: “The bottom line is that we need a step-by-step roadmap.”
+## Canned empathy and reader capture
+Assistant models are rewarded for being welcoming, reassuring, and broadly applicable. They often infer a generic emotional state, validate it, and promise relief before learning whether that state describes the reader.
+Ask what evidence the writer has about the reader. Watch for universal reassurance, broad audience triads, and emotional mirroring that never becomes specific to the situation.
+**Cross-domain examples:**
+- Marketing: “If growth feels overwhelming, you are not alone.”
+- Email: “You deserve an inbox that works for you.”
+- Social: “Curious what everyone thinks—does this resonate?”
+- Essay: “Imagine a world where every student feels seen.”
+- Workplace: “Whether you are new, experienced, or in between, this guide is for you.”
+## Timeless-sounding trend claims
+A changing-world opener makes almost any topic feel urgent. Models can invoke an era, rise, or accelerating trend without naming a date, dataset, event, or decision consequence.
+Demand a timestamp and a measurable change. Words such as *today*, *increasingly*, *ever-evolving*, *rise*, and *new era* need evidence or a concrete event.
+**Cross-domain examples:**
+- Marketing: “In today’s fast-moving market, attention is everything.”
+- Email: “Now more than ever, staying connected matters.”
+- Social: “We are entering a new era of personal creativity.”
+- Essay: “In an increasingly digital age, society faces unprecedented change.”
+- Workplace: “The business landscape is evolving faster than ever before.”
+## Inflated claims, vague virtues, and promotional vocabulary
+Positive, abstract language is a low-risk way for a model to sound useful and persuasive. Words about transformation, innovation, impact, trust, power, and potential can fill a sentence without committing to a measurable result.
+Circle the adjectives, intensifiers, and abstract nouns, then ask what observable fact each one replaces. If the claim cannot be measured, pictured, or falsified, the language is carrying it.
+**Cross-domain examples:**
+- Marketing: “Unlock transformative growth with our innovative solution.”
+- Email: “This powerful update will elevate your entire experience.”
+- Social: “A game-changing habit that can revolutionize your mornings.”
+- Essay: “This pivotal development underscores the profound importance of collaboration.”
+- Workplace: “Our robust framework will optimize outcomes at scale.”
+# The 220 patterns
+# Patterns 1–20
+## 1. It’s Not X, It’s Y
+**What it is:** Binary reframing that claims the real issue is something deeper, in the form “It’s not X, it’s Y.”
+**Why AI may reach for it:** The contrast gives the model an instant thesis: reject the obvious answer, then install a cleaner one. It creates certainty without making the model prove that X is false or that Y is sufficient.
+**Three typical AI examples:**
+- “It’s not about working harder; it’s about working smarter.”
+- “It’s not content; it’s distribution.”
+- “It’s not luck; it’s leverage.”
+**How to spot it:** Look for paired clauses built as “not X, but Y” or “it isn’t X; it’s Y.” Try replacing the opposition with “X and Y both matter”; if the claim still works, the binary was manufactured.
+**The ugly version:** It’s not about the product, it’s about the story. It’s not about the story, it’s about trust. And it’s not about trust, it’s about making people feel something.
+**Exception:** Use the frame when evidence genuinely rules out the first explanation and supports the second.
+**Good use:** The outage was not caused by traffic volume; the logs show that an expired certificate rejected every request.
+---
+## 2. Staccato Drama
+**What it is:** A run of very short, punchy sentences used for faux intensity.
+**Why AI may reach for it:** Short fragments let the model manufacture pace and emotional weight without developing an argument. Each full stop makes an ordinary point look like a reveal.
+**Three typical AI examples:**
+- “You tried. You failed. You learned.”
+- “Big idea. Tiny window. Act now.”
+- “No plan. No safety net. Just you.”
+**How to spot it:** Mark runs of three or more fragments or very short sentences with similar length. Join them into one ordinary sentence; if nothing is lost except drama, the rhythm was doing the work.
+**The ugly version:** No warning. No backup. No plan. Just panic. Pure panic. The kind that changes everything.
+**Exception:** Fragments can work when a deliberate pause, shock, or change of pace serves the scene or speaker.
+**Good use:** The monitor went black. Then the alarms started.
+---
+## 3. Ever-Evolving Landscape
+**What it is:** Grand, abstract opener about a constantly changing world, especially “in today’s fast-paced world” or “ever-evolving landscape.”
+**Why AI may reach for it:** A changing-world opener makes any topic sound current and urgent before the model has to name what changed. “Landscape” also hides the actors, events, and measurements behind a broad scene.
+**Three typical AI examples:**
+- “In today’s fast-paced world, attention is the new currency.”
+- “In the ever-evolving landscape of marketing, brand trust is everything.”
+- “In our increasingly digital age, standing out is harder than ever.”
+**How to spot it:** Search for “today’s fast-paced world,” “ever-evolving landscape,” “increasingly digital age,” and similar openers. Ask for the date, the measured change, the source, and the consequence; if none can be supplied, delete the opener.
+**The ugly version:** In today’s relentlessly fast-paced, ever-evolving digital landscape, brands must constantly evolve as the world continues changing at an unprecedented pace.
+---
+## 4. It’s Important to Note
+**What it is:** Hedging preface that adds faux gravitas to an obvious statement.
+**Why AI may reach for it:** The preface lets the model sound cautious and authoritative without deciding whether the following fact is surprising, risky, or central. It adds a warning label before identifying a hazard.
+**Three typical AI examples:**
+- “It’s important to note that not all growth is good growth.”
+- “It’s important to note that this is not legal advice.”
+- “It’s important to note that every audience is different.”
+**How to spot it:** Find “it’s important to note,” “it should be noted,” and “it is worth emphasizing.” Remove the preface; if the sentence has the same force and meaning, the phrase added gravitas rather than information.
+**The ugly version:** It’s important to note that consistency is important, and it’s also important to note that results may vary depending on a variety of important factors.
+---
+## 5. Let’s Dive In
+**What it is:** Overused invitation to start, often following a fluffy intro.
+**Why AI may reach for it:** The phrase is an easy bridge from a generic introduction into the answer. It signals motion while postponing the first concrete point.
+**Three typical AI examples:**
+- “Let’s dive in and explore how this works.”
+- “Let’s dive into the key strategies you can use today.”
+- “Let’s dive in and break this down step by step.”
+**How to spot it:** Search for “let’s dive in,” “let’s dive into,” and “without further ado, let’s dive.” Delete the sentence and read the next one; if the piece starts faster and loses no instruction, it was throat-clearing.
+**The ugly version:** Now that we’ve set the stage, let’s dive in, dive deep, and really dive into the key ideas you need to know before we dive even deeper.
+**Exception:** It can suit live facilitation when the speaker is explicitly inviting a group to begin a shared examination.
+**Good use:** We have ten minutes left, so let’s dive into the two failed requests in the log.
+---
+## 6. Whether You’re X, Y, or Z
+**What it is:** Inclusive triad that tries to cover all readers at once.
+**Why AI may reach for it:** A three-part audience sweep lets the model imply universal relevance without choosing a reader. The categories usually sound inclusive but do not change the advice.
+**Three typical AI examples:**
+- “Whether you’re a founder, marketer, or creator, this applies to you.”
+- “Whether you’re just starting out, scaling, or already established, you’ll find value here.”
+- “Whether you’re introverted, extroverted, or somewhere in between, these tactics can help.”
+**How to spot it:** Look for “whether you’re A, B, or C” followed by one promise for everyone. Remove the categories; if the same advice remains, or if the three groups need different instructions, the audience claim is decorative.
+**The ugly version:** Whether you’re a founder, freelancer, full-time employee, first-time creator, seasoned expert, curious beginner, or simply someone somewhere in between, this guide is for you.
+**Exception:** Use the construction when the named groups are the actual supported audience and the next text clearly branches for them.
+**Good use:** Whether you’re an owner, tenant, or property manager, choose your role below to see the documents you must submit.
+---
+## 7. On the One Hand / On the Other Hand
+**What it is:** Forced balanced framing that presents both sides even when not needed.
+**Why AI may reach for it:** Balanced clauses give the model a ready-made shape that looks fair-minded. It can fill both sides even when the evidence strongly favors one or the decision does not require equal treatment.
+**Three typical AI examples:**
+- “On the one hand, automation saves time. On the other hand, it can feel impersonal.”
+- “On the one hand, raising prices boosts margins; on the other hand, it risks churn.”
+- “On the one hand, AI is efficient; on the other, it raises ethical questions.”
+**How to spot it:** Mark “on the one hand/on the other hand” pairs. Ask whether both sides affect the same decision, carry comparable evidence, and deserve equal weight; if not, state the stronger conclusion directly.
+**The ugly version:** On the one hand, the server is on fire. On the other hand, restarting it might interrupt a few active sessions, so there are compelling arguments on both sides.
+**Exception:** Use the pair for a real two-sided decision when both effects matter and the criterion for choosing is stated.
+**Good use:** On the one hand, annual billing improves cash flow; on the other, our trial data shows a 19% lower conversion rate. We will test both plans for one quarter.
+---
+## 8. Not Only… But Also
+**What it is:** Parallel structure that over-polishes simple comparisons.
+**Why AI may reach for it:** The paired syntax lets the model enlarge a modest claim by attaching a second benefit. The grammatical symmetry can imply that both claims are proven even when one is merely promotional.
+**Three typical AI examples:**
+- “It’s not only fast, but also incredibly flexible.”
+- “This strategy not only drives revenue but also deepens loyalty.”
+- “Great design not only looks good but also solves real problems.”
+**How to spot it:** Search for “not only” followed by “but also.” Check whether the second clause genuinely adds a distinct, supported point; if “and” says the same thing more cleanly, use it.
+**The ugly version:** The platform not only transforms how you work but also revolutionizes how you think, while not only saving time but also unlocking unprecedented possibilities.
+**Exception:** Use the construction when the second point is a meaningful escalation or surprise and both halves deserve emphasis.
+**Good use:** The leak not only damaged the archive; it also exposed the electrical wiring.
+---
+## 9. At the End of the Day
+**What it is:** Tired closer that pretends to reveal the core truth.
+**Why AI may reach for it:** The phrase offers a prebuilt closing and tells the reader that a final simplification is coming. It often replaces the work of showing why one conclusion outweighs the rest.
+**Three typical AI examples:**
+- “At the end of the day, brand is how people feel about you.”
+- “At the end of the day, data is only useful if you act on it.”
+- “At the end of the day, consistency beats intensity.”
+**How to spot it:** Find “at the end of the day” near conclusions. Remove it and test the remaining claim for evidence and specificity; if the sentence becomes an unsupported slogan, the closer was supplying false authority.
+**The ugly version:** At the end of the day, when all is said and done and everything is taken into account, success ultimately comes down to succeeding.
+---
+## 10. From A to Z Completeness
+**What it is:** Promise of exhaustive coverage using “from X to Y” framing.
+**Why AI may reach for it:** A from-to range lets the model imply complete coverage with two endpoints. It avoids naming the missing stages, exclusions, or handoffs between them.
+**Three typical AI examples:**
+- “From ideation to execution, every step matters.”
+- “From awareness to advocacy, your funnel needs coherence.”
+- “From first click to final purchase, the experience must feel seamless.”
+**How to spot it:** Look for “from A to Z,” “from idea to execution,” and “from first click to purchase.” List the actual stages; if the endpoints skip material steps or the piece covers only part of the range, narrow the claim.
+**The ugly version:** This complete guide covers everything from the first spark of an idea to flawless global execution and every imaginable step, stage, detail, and decision in between.
+**Exception:** Use a from-to range when the endpoints are real boundaries and the material covers the intervening process.
+**Good use:** The audit follows each order from checkout through payment, fulfilment, delivery, and refund.
+---
+## 11. You’re in the Right Place
+**What it is:** SEO-style reassurance that mirrors the search query back to the reader.
+**Why AI may reach for it:** Mirroring the reader’s search phrase is a cheap way to create reassurance and keep them on the page. The model can promise fit before it knows the reader’s situation.
+**Three typical AI examples:**
+- “If you’re looking to grow your newsletter, you’re in the right place.”
+- “If you want to build a memorable brand, you’re in the right place.”
+- “If you’ve ever struggled with content consistency, you’re in the right place.”
+**How to spot it:** Search for “you’re in the right place” after an “if you want” or “if you’re looking for” clause. Check whether the page states who it serves, what it provides, and who should leave; if not, the reassurance is empty.
+**The ugly version:** If you’re looking for the one ultimate guide that finally answers every question you have ever had about content, congratulations: you are absolutely in the right place.
+**Exception:** The phrase can orient a visitor when the page immediately confirms a narrow intent and gives a concrete route forward.
+**Good use:** If you need to replace a UK passport that expires within six months, you’re in the right place. Start with the eligibility check below.
+---
+## 12. Here’s a Step-by-Step Guide
+**What it is:** Fixed promise of a linear, numbered solution regardless of problem complexity.
+**Why AI may reach for it:** A numbered guide gives the model a stable container and a visible sense of progress. It can force uncertain, iterative, or parallel work into a false linear sequence.
+**Three typical AI examples:**
+- “Here’s a step-by-step guide to launching your first product.”
+- “Here’s a step-by-step guide to building trust with your audience.”
+- “Here’s a step-by-step guide to validating your idea.”
+**How to spot it:** Look for a “step-by-step guide” promise and test whether each step has a prerequisite, action, and completion condition. If the items can happen in any order or depend on feedback, call them options, checks, or phases instead.
+**The ugly version:** Here is the definitive step-by-step guide to becoming unforgettable: Step 1, be authentic. Step 2, add value. Step 3, stay consistent. Step 4, watch success happen.
+**Exception:** Use the label for a repeatable procedure whose order matters.
+**Good use:** Here is a step-by-step guide to rotating the key: create the new key, deploy it, verify traffic, then revoke the old one.
+---
+## 13. First, Second, Third
+**What it is:** Rigid signposting that over-explains structure instead of just flowing.
+**Why AI may reach for it:** Ordinal transitions help the model track its own output and make unrelated points look sequenced. The labels can hide that the ideas are equal, incomplete, or arbitrarily ordered.
+**Three typical AI examples:**
+- “First, define your audience. Second, clarify your offer. Third, choose your channel.”
+- “First, gather data. Second, identify patterns. Third, test hypotheses.”
+- “First, listen. Second, learn. Third, lead.”
+**How to spot it:** Mark “first,” “second,” and “third” at paragraph openings. Swap the order; if the argument still works, or if no later sentence depends on an earlier one, the numbering is probably scaffolding.
+**The ugly version:** First, believe in your vision. Second, trust the process. Third, embrace the journey. Fourth, remember the first three things.
+**Exception:** Use ordinal signposts when order, rank, or later reference matters.
+**Good use:** First isolate the circuit, second verify zero voltage, and third attach the lockout tag.
+---
+## 14. Ultimately, What Matters
+**What it is:** Soft-sounding but generic conclusion using “ultimately” to signal a wrap-up.
+**Why AI may reach for it:** “Ultimately” lets the model announce a hierarchy without comparing the competing factors. “What matters” turns a broad preference into a final verdict.
+**Three typical AI examples:**
+- “Ultimately, what matters is whether your message resonates.”
+- “Ultimately, the best strategy is the one you’ll actually execute.”
+- “Ultimately, trust compounds faster than tactics.”
+**How to spot it:** Find conclusions beginning with “ultimately” or “ultimately, what matters.” Ask which alternatives were weighed and what evidence makes this factor decisive; if the answer is missing, remove the ranking.
+**The ugly version:** Ultimately, what ultimately matters most at the end of the day is what truly matters to you, your audience, and the future of meaningful success.
+---
+## 15. In Other Words
+**What it is:** Redundant rephrasing that restates the same idea with minimal new insight.
+**Why AI may reach for it:** The phrase lets the model restate a sentence and spend more tokens without advancing it. A near-synonym can look like clarification even when the abstraction level never changes.
+**Three typical AI examples:**
+- “In other words, your brand is your promise in action.”
+- “In other words, data without decisions is useless.”
+- “In other words, if they don’t remember you, you don’t exist.”
+**How to spot it:** Compare the clauses before and after “in other words.” If the second does not become plainer, more concrete, or more audience-appropriate, delete it.
+**The ugly version:** The strategy requires strategic alignment. In other words, the strategy must align strategically with the strategic direction.
+**Exception:** Use it to translate a technical or unfamiliar statement into language the defined audience can act on.
+**Good use:** The account is in arrears. In other words, the payment due on 1 June has not arrived.
+---
+## 16. To Put It Simply
+**What it is:** Claims simplicity before delivering a slightly rephrased but still abstract statement.
+**Why AI may reach for it:** The cue promises compression before the model has actually simplified the idea. It can make a vague definition feel accessible by announcing simplicity rather than producing it.
+**Three typical AI examples:**
+- “To put it simply, positioning is choosing what you want to be known for.”
+- “To put it simply, churn is the opposite of loyalty.”
+- “To put it simply, strategy is saying no more than saying yes.”
+**How to spot it:** Find “to put it simply” and inspect the sentence that follows. If it retains unexplained terms, deletes a necessary condition, or is no shorter than the original, the cue is false.
+**The ugly version:** To put it simply, strategic differentiation is the multidimensional optimization of contextually relevant value propositions across stakeholder ecosystems.
+**Exception:** Use it before a genuinely plain, accurate restatement that preserves the important limits.
+**Good use:** To put it simply, the drug lowers blood pressure; it does not cure the condition.
+---
+## 17. Imagine This / Picture This
+**What it is:** Paints a generic scenario as a hook, usually with low specificity.
+**Why AI may reach for it:** A generic imagined future supplies an emotional hook without requiring observed detail. The model can insert an ideal outcome and let the reader furnish the missing evidence.
+**Three typical AI examples:**
+- “Imagine this: you wake up to a calendar full of qualified leads.”
+- “Picture this: your content works for you while you sleep.”
+- “Imagine this: your brand becomes the default choice in your category.”
+**How to spot it:** Search for “imagine this” or “picture this,” then list the concrete sensory, operational, or factual details in the scene. If the scenario is only a wish with no mechanism or purpose, cut the invitation.
+**The ugly version:** Picture this: you wake up, open your laptop, and discover that your brand has become iconic overnight while qualified leads pour in and passive income flows effortlessly.
+**Exception:** Use guided imagination when a concrete hypothetical helps the reader rehearse a decision, scene, or procedure.
+**Good use:** Picture the junction at 8 a.m.: the school gate is on your left, buses block the near lane, and you have six seconds to cross.
+---
+## 18. The X of Y
+**What it is:** Metaphoric positioning using the “X of Y” formula.
+**Why AI may reach for it:** Borrowing a famous company or system gives the model an instant bundle of associations. It substitutes a recognizable label for the specific product mechanics, market, and constraints.
+**Three typical AI examples:**
+- “Build the Netflix of personal finance content.”
+- “Think of this as the operating system of your brand.”
+- “You don’t want to be the Uber of nothing; you want to own a real problem.”
+**How to spot it:** Look for “the Netflix of,” “the Uber of,” “the operating system of,” and similar X-of-Y labels. Ask which exact properties transfer and which do not; if the writer cannot name them, the comparison is branding fog.
+**The ugly version:** We are building the Netflix of finance, the Uber of advice, and the operating system of wealth for anyone who wants the Apple of personal growth.
+**Exception:** Use the analogy when a precise shared mechanism helps an audience understand an unfamiliar system.
+**Good use:** The scheduler is the hotel booking desk of the machine room: each machine is a room, and each reservation blocks a fixed time slot.
+---
+## 19. The Bottom Line Is
+**What it is:** Overused phrase to signal a supposed hard truth.
+**Why AI may reach for it:** The label creates the sound of a decisive commercial conclusion. It can turn a platitude into a verdict without showing the calculation or decision behind it.
+**Three typical AI examples:**
+- “The bottom line is: people buy feelings, not features.”
+- “The bottom line is that retention beats acquisition.”
+- “The bottom line is: clarity converts, confusion kills.”
+**How to spot it:** Find “the bottom line is” and ask for the actual result, choice, owner, or consequence. If the following text is a slogan rather than a decision, remove the label.
+**The ugly version:** The bottom line is that the real bottom line comes down to one bottom line: brands that win are winners because they know how to win.
+**Exception:** Use it in decision-focused business writing when it points to a concrete result or required action after the supporting detail.
+**Good use:** The bottom line is a £42,000 annual loss, so we will close the warehouse at the end of September.
+---
+## 20. X Is Not Just About Y
+**What it is:** Claims a topic is deeper than the obvious, usually without adding much depth.
+**Why AI may reach for it:** The frame gives the model a ready-made depth move: dismiss the familiar view and announce a broader one. It often adds a second abstract noun without showing how the dimensions relate.
+**Three typical AI examples:**
+- “Brand is not just about logos; it’s about perception.”
+- “Pricing is not just about numbers; it’s about narrative.”
+- “Strategy is not just about plans; it’s about priorities.”
+**How to spot it:** Search for “not just about” and “more than.” Name the additional mechanism or consequence; if the sentence merely swaps one broad label for another, rewrite the claim directly.
+**The ugly version:** Branding is not just about logos; it is about identity, emotion, connection, culture, trust, belonging, purpose, impact, and everything your business could ever mean.
+**Exception:** Use the contrast when readers commonly reduce the subject to one component and the sentence names a distinct, relevant component.
+**Good use:** Accessibility is not just about screen readers; keyboard-only users also need every control to receive focus.
+---
+# Patterns 21–40
+## 21. It’s Easy to Feel X
+**What it is:** Faux empathy that opens with “it’s easy to feel,” then normalizes a common anxiety.
+**Why AI may reach for it:** The opener fabricates familiarity by assigning the reader a plausible feeling. That emotional assumption lets the model sound empathetic before it has any evidence about this audience.
+**Three typical AI examples:**
+- “It’s easy to feel overwhelmed by all the growth advice out there.”
+- “It’s easy to feel behind when you see others posting wins daily.”
+- “It’s easy to feel stuck when your metrics plateau.”
+**How to spot it:** Mark “it’s easy to feel” followed by an emotion. Ask where the reader reported that feeling and whether the text helps with its concrete cause; if neither exists, state the situation without mind-reading.
+**The ugly version:** It’s easy to feel overwhelmed, unseen, uncertain, exhausted, inspired, excited, and somehow ready for what comes next.
+**Exception:** Use the validation when the audience has directly reported the feeling and the next sentence addresses its documented cause.
+**Good use:** It’s easy to feel overwhelmed by this form: 61% of new carers reported that reaction in our exit survey. Start with the three required fields marked in blue.
+---
+## 22. The Truth Is / The Reality Is
+**What it is:** Claims to reveal hidden truth, usually a platitude.
+**Why AI may reach for it:** The reveal phrase lets the model promote an ordinary claim into hidden knowledge. It asks the reader to accept the speaker’s certainty before seeing evidence.
+**Three typical AI examples:**
+- “The truth is, most brands don’t have a positioning problem; they have a focus problem.”
+- “The reality is, no one cares about your product—they care about their problems.”
+- “The truth is, consistency beats cleverness.”
+**How to spot it:** Search for “the truth is” and “the reality is.” Remove the reveal and test the remaining sentence: if it is a truism, unsupported generalization, or false universal, the phrase was carrying it.
+**The ugly version:** The truth is, the reality is, most people are simply not ready to hear the deeper truth about what reality really requires.
+---
+## 23. On the Surface… But Beneath
+**What it is:** Two-layer contrast that sets up a deeper interpretation.
+**Why AI may reach for it:** A surface/depth pair gives the model an easy diagnostic arc: name an obvious cause, then replace it with a more impressive hidden cause. The second layer can sound insightful without evidence.
+**Three typical AI examples:**
+- “On the surface, it looks like a pricing issue. But beneath that, it’s a positioning issue.”
+- “On the surface, churn seems like a product problem; beneath it, it’s often a trust problem.”
+- “On the surface, it’s about content; beneath it, it’s about conviction.”
+**How to spot it:** Look for “on the surface” followed by “beneath,” “underneath,” or “really.” Ask what observation distinguishes the surface explanation from the deeper one; if no test or evidence does, keep both as hypotheses.
+**The ugly version:** On the surface, the problem looks like traffic. Beneath the surface, it is positioning. Beneath that, it is trust. Beneath trust, it is purpose. Beneath purpose lies the real problem: depth.
+**Exception:** Use the contrast when a first observation and a later examination produce different, evidenced conclusions.
+**Good use:** On the surface, the failures looked random; beneath that pattern, every request came from the same expired client.
+---
+## 24. In the World / Realm of X
+**What it is:** Abstract domain framing like “in the world of X” or “in the realm of Y.”
+**Why AI may reach for it:** “World” and “realm” give the model a grand setting without naming a market, jurisdiction, discipline, or boundary. The domain sounds established while remaining undefined.
+**Three typical AI examples:**
+- “In the world of SaaS, churn is a silent killer.”
+- “In the realm of personal branding, trust is the only real moat.”
+- “In the world of DTC brands, attention is brutally expensive.”
+**How to spot it:** Search for “in the world of” and “in the realm of.” Replace the phrase with the actual field, place, or group; if the sentence becomes clearer immediately, the domain framing was ornamental.
+**The ugly version:** In the ever-shifting realm of the world of modern business, visionary leaders navigate a universe where every possibility exists.
+**Exception:** Use “world” or “realm” literally in fiction, games, or analysis of a defined fictional setting.
+**Good use:** In the world of Earthsea, names carry power because they reveal a thing’s true nature.
+---
+## 25. As an AI Language Model
+**What it is:** Self-referential disclaimer that foregrounds model limitations.
+**Why AI may reach for it:** The stock disclosure lets the model handle questions about identity, experience, or capability with one memorized boundary. It can appear even when the limitation has no bearing on the request.
+**Three typical AI examples:**
+- “As an AI language model, I don’t have personal experiences.”
+- “As an AI language model, I can’t provide medical advice.”
+- “As an AI language model, I don’t have feelings or opinions.”
+**How to spot it:** Find “as an AI language model” and ask whether identity, capability, consent, or provenance changes the answer. If the disclosure does not alter what follows, remove it.
+**The ugly version:** As an AI language model, I do not eat breakfast, experience Mondays, possess childhood memories, feel excitement, or personally enjoy the spreadsheet you asked me to format.
+**Exception:** Disclose AI identity when the user could reasonably mistake the system for a person or when capability, consent, or accountability depends on it.
+**Good use:** As an AI assistant, I cannot witness the damage or sign the insurance declaration.
+---
+## 26. I Can’t Provide X Advice
+**What it is:** Safety disclaimer about legal, financial, or medical topics.
+**Why AI may reach for it:** A broad refusal is a safe completion for high-stakes topics and avoids calculating the exact line between general information and personalized instruction. The model may repeat the boundary instead of giving the useful, permitted part.
+**Three typical AI examples:**
+- “I can’t provide legal advice, but here are general considerations.”
+- “I can’t provide personalized investment recommendations.”
+- “I can’t provide medical advice; consult a professional.”
+**How to spot it:** Look for “I can’t provide legal, medical, or financial advice.” Identify the exact risky action or missing fact; if the response could safely provide general information, warning signs, or questions to ask, the blanket disclaimer is too broad.
+**The ugly version:** I can’t provide medical advice, legal advice, financial advice, nutritional advice, career advice, relationship advice, or advice about which advice you should seek.
+**Exception:** Use a clear boundary when personalized guidance would be unsafe, unauthorized, or dependent on facts the system cannot verify.
+**Good use:** I can explain common causes of chest pain, but I cannot determine yours. Sudden chest pressure with shortness of breath needs urgent medical assessment.
+---
+## 27. Key Takeaways
+**What it is:** Explicit “key takeaways” section that summarizes obvious points.
+**Why AI may reach for it:** A takeaway section gives the model a familiar ending and another chance to restate its own output. It can label ordinary repetition as retrieval support.
+**Three typical AI examples:**
+- “Here are the key takeaways from this approach.”
+- “Key takeaways: clarity, consistency, and compounding.”
+- “Key takeaways: know your audience, nail your offer, refine your message.”
+**How to spot it:** Find “key takeaways” and compare each bullet with the preceding section. If the document is short or the bullets merely repeat nearby sentences without ranking or compression, delete the section.
+**The ugly version:** Key takeaways: remember the key points, focus on what matters, take action on the actionable items, and do not forget these key takeaways.
+**Exception:** Use a takeaway layer after long or technical material when it compresses the main findings and preserves their limits.
+**Good use:** Key takeaways: the trial missed its primary endpoint; the safety signal was unchanged; no treatment recommendation follows from this study.
+---
+## 28. Actionable Tips
+**What it is:** Framing advice as “actionable tips” regardless of specificity.
+**Why AI may reach for it:** Calling advice “actionable” lets the model claim usefulness without supplying an action, owner, input, or result. The label stands in for operational detail.
+**Three typical AI examples:**
+- “Here are three actionable tips to improve your onboarding.”
+- “Below are actionable tips to boost your open rates.”
+- “Use these actionable tips to sharpen your positioning.”
+**How to spot it:** Search for “actionable tip,” “actionable insight,” and “actionable strategy.” For each item, ask who does what, with which input, by when, and how completion is visible; if those answers are missing, the tip is not actionable.
+**The ugly version:** Here are three actionable tips: be more strategic, create better content, and consistently optimize everything for maximum impact.
+**Exception:** The label is accurate when every tip specifies a concrete action and observable result.
+**Good use:** Actionable tip: before Friday, export the last 30 days of failed payments and call the ten customers with the highest account value.
+---
+## 29. Overwhelming but It Doesn’t Have To Be
+**What it is:** Sets up overwhelm then offers reassurance and a simple plan.
+**Why AI may reach for it:** The model creates a problem-and-relief arc by assigning overwhelm, then promising simplicity. It can reassure before explaining what makes the task hard.
+**Three typical AI examples:**
+- “Marketing can feel overwhelming, but it doesn’t have to be.”
+- “Building a brand seems complex, but it doesn’t have to be.”
+- “Data can be intimidating, but it doesn’t have to be.”
+**How to spot it:** Look for “can feel overwhelming, but it doesn’t have to be.” Ask whether the audience reported overwhelm and whether the next sentence removes a real source of complexity; if not, the empathy is staged.
+**The ugly version:** Everything can feel impossibly overwhelming, confusing, and exhausting, but it absolutely does not have to be once you embrace this one beautifully simple framework.
+**Exception:** Use the reassurance when the audience has documented difficulty and the text immediately removes a specific burden.
+**Good use:** The 18-page form can feel overwhelming, but it doesn’t have to be: renewal applicants only complete sections 1, 3, and 7.
+---
+## 30. The Good News Is
+**What it is:** Hopeful pivot after highlighting a problem.
+**Why AI may reach for it:** The hopeful pivot gives the model an easy emotional turn after stating a problem. It can present an unsupported upside as relief.
+**Three typical AI examples:**
+- “The good news is you don’t need a huge audience to win.”
+- “The good news is most competitors never follow through.”
+- “The good news is small, consistent actions compound.”
+**How to spot it:** Find “the good news is” and isolate the claim that follows. Ask what makes it good, for whom, and what evidence supports it; if it is merely a generic encouragement, state the fact directly.
+**The ugly version:** The good news is that every setback is secretly an opportunity, every problem is really a gift, and every closed door is preparing to open a better one.
+**Exception:** Use the phrase in a status update when a concrete favorable result directly answers the concern just raised.
+**Good use:** The shipment missed Tuesday’s cutoff. The good news is that the carrier confirmed Friday delivery at no extra cost.
+---
+## 31. The Bad News Is
+**What it is:** Negative pivot to emphasize stakes.
+**Why AI may reach for it:** The negative pivot supplies instant stakes and a clean setup for the model’s proposed solution. It can exaggerate a routine constraint to make the next advice feel necessary.
+**Three typical AI examples:**
+- “The bad news is nobody cares about your brand yet.”
+- “The bad news is algorithms don’t owe you reach.”
+- “The bad news is attention keeps getting more expensive.”
+**How to spot it:** Search for “the bad news is.” Name the measurable loss, affected party, and timeframe; if the phrase introduces a broad fear rather than a fact, remove the drama.
+**The ugly version:** The bad news is your audience is distracted, your competitors are relentless, the algorithm is unforgiving, and everything is getting harder every single day.
+**Exception:** Use the phrase when delivering a concrete adverse development alongside its consequence and next action.
+**Good use:** The bad news is that the backup stopped running on 12 May. Do not delete the source files until tonight’s full backup is verified.
+---
+## 32. X Has Been Around for Centuries
+**What it is:** Trivial pseudo-historical opener.
+**Why AI may reach for it:** A centuries-long preface gives the model borrowed historical depth without requiring a relevant history. It usually delays a modern claim with an unfalsified generalization.
+**Three typical AI examples:**
+- “Storytelling has been around for centuries, but the platforms have changed.”
+- “Branding has been around for centuries, even before logos existed.”
+- “Negotiation has been part of human interaction for centuries.”
+**How to spot it:** Look for “has been around for centuries.” Ask for the earliest evidence, the actual continuity, and why that history changes the present argument; if it does not, start with the present.
+**The ugly version:** Storytelling has been around for centuries, since people first told stories centuries ago, proving that storytelling will remain timeless for centuries to come.
+**Exception:** Use the history when the duration is documented and materially explains the current practice.
+**Good use:** Smallpox inoculation had been practised in parts of Asia for centuries before eighteenth-century accounts brought the method to wider British attention.
+---
+## 33. Since the Dawn of Time
+**What it is:** Grandiose exaggeration for basic concepts.
+**Why AI may reach for it:** The phrase turns a broad human tendency into timeless destiny. It gives the model grandeur while avoiding dates, cultures, counterexamples, and change.
+**Three typical AI examples:**
+- “Since the dawn of time, humans have traded value for value.”
+- “Since the dawn of time, stories have shaped how people see the world.”
+- “Since the dawn of time, trust has underpinned every transaction.”
+**How to spot it:** Search for “since the dawn of time.” Treat it as a universal historical claim: if the writer cannot define the starting period and support continuity, cut it.
+**The ugly version:** Since the dawn of time, humans have always built brands, optimized funnels, cultivated audiences, and understood the timeless importance of authentic engagement.
+---
+## 34. In a Nutshell
+**What it is:** Casual summary phrase that rarely adds clarity.
+**Why AI may reach for it:** The phrase promises a compact summary and lets the model recycle a slogan as explanation. It often reduces a complex point past the point of usefulness.
+**Three typical AI examples:**
+- “In a nutshell, your brand is what people say about you when you’re not in the room.”
+- “In a nutshell, positioning is choosing your enemy.”
+- “In a nutshell, retention is trust on a timeline.”
+**How to spot it:** Find “in a nutshell” and compare the summary with the full claim. If it drops a condition, adds a slogan, or is no shorter than a plain sentence, remove the wrapper.
+**The ugly version:** In a nutshell, the nutshell of the matter is that everything comes down to clarity, consistency, authenticity, and the courage to crack the nutshell.
+**Exception:** Use it in informal prose before a genuinely shorter statement that preserves the important condition.
+**Good use:** In a nutshell, the plan costs less now but locks us into the supplier for three years.
+---
+## 35. Let’s Break It Down
+**What it is:** Promise to decompose a concept into simpler parts.
+**Why AI may reach for it:** The invitation promises decomposition before the model has identified real parts. It can precede an arbitrary three-item list that only makes the answer look teachable.
+**Three typical AI examples:**
+- “Let’s break it down into three core pillars.”
+- “Let’s break it down step-by-step so you can implement it.”
+- “Let’s break it down into what actually matters.”
+**How to spot it:** Search for “let’s break it down.” Check whether the following parts are distinct, jointly cover the subject, and are easier to test separately; if not, start with the first concrete point.
+**The ugly version:** Let’s break it down into the three pillars of breakthrough growth: clarity, momentum, and the powerful clarity that creates sustainable momentum.
+**Exception:** Use the phrase in live or conversational teaching when the following decomposition is real and useful.
+**Good use:** Let’s break the invoice total down into labour, materials, tax, and the late fee.
+---
+## 36. Step 1 / Step 2 / Step 3
+**What it is:** Rigid procedural framing even for non-procedural topics.
+**Why AI may reach for it:** Explicit step labels give the model a stable sequence and make advice look executable. The order may be invented even when the actions are independent, iterative, or missing prerequisites.
+**Three typical AI examples:**
+- “Step 1: Define your ICP. Step 2: Craft your promise. Step 3: Choose your channel.”
+- “Step 1: Audit your content. Step 2: Cut the noise. Step 3: Double down on what works.”
+- “Step 1: Listen. Step 2: Learn. Step 3: Lead.”
+**How to spot it:** Find Step 1, Step 2, and Step 3 labels. Swap two steps and ask whether anything fails; if not, use bullets. Also check that each step has an action and completion condition.
+**The ugly version:** Step 1: Find your purpose. Step 2: Become authentic. Step 3: Build trust. Step 4: Scale your impact. Step 5: Repeat the journey until success.
+**Exception:** Use numbered steps for an ordered procedure with real dependencies.
+**Good use:** Step 1: disconnect the power. Step 2: test for voltage. Step 3: remove the cover.
+---
+## 37. Pros and Cons
+**What it is:** Standard pros/cons framing applied to everything.
+**Why AI may reach for it:** A pros-and-cons table is a dependable way for the model to fill both sides of any topic. It can flatten differences in probability, severity, ownership, and evidence into equal-looking bullets.
+**Three typical AI examples:**
+- “Here are the pros and cons of niching down.”
+- “Let’s explore the pros and cons of daily publishing.”
+- “There are pros and cons to using paid ads early.”
+**How to spot it:** Look for automatic pros/cons framing. Ask whether the decision is bounded, the factors are comparable, and each item is weighted for the affected party; if not, use criteria or scenarios instead.
+**The ugly version:** Pros of a data breach: learning opportunity, team bonding, and greater awareness. Cons: legal exposure, customer harm, and a slightly stressful week.
+**Exception:** Use the structure for a bounded choice when benefits and costs are comparable and weighted.
+**Good use:** Pros of the annual plan: £4,800 lower cost. Cons: a 12-month commitment and no midyear seat reduction.
+---
+## 38. On the Flip Side
+**What it is:** Casual contrast phrase to introduce the opposite view.
+**Why AI may reach for it:** The phrase gives the model a casual switch to an opposite point. It can create a false reversal where the next sentence is only another caveat or loosely related fact.
+**Three typical AI examples:**
+- “On the flip side, too much automation can hurt trust.”
+- “On the flip side, staying too niche can limit your upside.”
+- “On the flip side, chasing every trend destroys consistency.”
+**How to spot it:** Find “on the flip side.” Check whether the next claim truly reverses the previous claim and changes the decision; if it merely adds information, use a precise connection or none.
+**The ugly version:** The campaign doubled sales. On the flip side, the logo is blue. On the flip side of that, blue can feel trustworthy, which flips the whole strategy.
+**Exception:** Use it in informal prose when the next point is a genuine countereffect.
+**Good use:** The smaller batch cuts waste. On the flip side, it raises the unit cost by 14%.
+---
+## 39. However, It’s Important to Remember
+**What it is:** Hedged contrast that softens any strong claim.
+**Why AI may reach for it:** Stacking “however” with a reminder preface lets the model soften a claim twice. The padding creates caution without naming the exact limit.
+**Three typical AI examples:**
+- “However, it’s important to remember that tactics change, but principles last.”
+- “However, it’s important to remember that virality doesn’t equal loyalty.”
+- “However, it’s important to remember that more content is not always better.”
+**How to spot it:** Search for the full phrase and separate its jobs: contrast, warning, and reminder. If the following condition can be stated directly beside the claim it limits, remove the ceremonial lead-in.
+**The ugly version:** However, it’s important to remember that, while this strategy always works, it may not work for everyone in every situation, which is important to keep in mind.
+**Exception:** Use a reminder when an earlier condition would otherwise be forgotten and materially changes the next action.
+**Good use:** However, remember that the test environment uses fake card numbers; do not use these results to reconcile live payments.
+---
+## 40. That Said
+**What it is:** Short reversal signal that appears constantly in AI prose.
+**Why AI may reach for it:** “That said” is a compact transition the model can reuse whenever it wants to qualify itself. Repetition makes each paragraph sound balanced even when the relation is weak.
+**Three typical AI examples:**
+- “That said, not every brand needs to be everywhere.”
+- “That said, you don’t need fancy tools to get started.”
+- “That said, copying others rarely leads to differentiation.”
+**How to spot it:** Mark every “that said.” For each one, identify the exact prior claim being limited or reversed; if no clear claim exists, delete the transition.
+**The ugly version:** That said, consistency matters. That said, flexibility matters too. That said, the real answer is balance. That said, balance also depends.
+**Exception:** Use it when the next sentence directly limits or reverses the previous one.
+**Good use:** The patch passed every automated test. That said, we have not tested it with the legacy scanner.
+---
+# Patterns 41–60
+## 41. At Its Core, X Is Y
+**What it is:** Essence statement that defines a concept in broad terms.
+**Why AI may reach for it:** “At its core” lets the model compress a contested concept into one polished essence. It can make a broad definition sound settled without stating its scope.
+**Three typical AI examples:**
+- “At its core, branding is about meaning.”
+- “At its core, strategy is about choices.”
+- “At its core, marketing is about moving people to act.”
+**How to spot it:** Find “at its core” definitions. Ask whether the subject has one necessary property and whether the sentence states a testable definition; if it only names a virtue, remove the essence claim.
+**The ugly version:** At its core, business is about people, and at the core of people is trust, while at the core of trust is authentic human connection.
+**Exception:** Use it when naming a precise defining property within a stated scope.
+**Good use:** At its core, public-key encryption separates the key used to encrypt data from the key used to decrypt it.
+---
+## 42. Think of X as Y
+**What it is:** Analogy invitation that often oversimplifies.
+**Why AI may reach for it:** The invitation primes the reader to accept an analogy before the model has mapped its limits. A familiar image can replace the mechanism it was meant to explain.
+**Three typical AI examples:**
+- “Think of your brand as a promise you keep repeatedly.”
+- “Think of positioning as the story you choose to own.”
+- “Think of onboarding as the trailer for the full movie.”
+**How to spot it:** Search for “think of X as Y.” Write down the matching properties and the point where the analogy fails; if the mapping is vague or misleading, explain the mechanism directly.
+**The ugly version:** Think of your brand as a garden, your funnel as a river, your content as seeds, and your customers as ships navigating the harvest.
+**Exception:** Use the analogy when it clarifies a specific unfamiliar relationship and its limits are clear.
+**Good use:** Think of the queue as a deli ticket system: each job waits its turn, but urgent jobs can be assigned a higher priority.
+---
+## 43. X Is Like Y
+**What it is:** Basic simile comparing abstract things.
+**Why AI may reach for it:** A simile lets the model make an abstract noun feel concrete with almost any familiar object. The resemblance can be emotional rather than explanatory.
+**Three typical AI examples:**
+- “Your brand is like a reputation that travels faster than you do.”
+- “Your funnel is like a series of first dates.”
+- “Your content is like open-source proof of work.”
+**How to spot it:** Mark “X is like Y” comparisons. Name the exact shared relationship; if the comparison could fit dozens of other subjects or adds only mood, replace it with the literal claim.
+**The ugly version:** Your brand is like a lighthouse in a garden, your funnel is like a first date on a bridge, and your strategy is like a compass planting seeds.
+**Exception:** Use a simile when the shared property is precise and helps the audience understand the subject.
+**Good use:** A cache is like a desk drawer: frequently used items stay close, but the drawer must be refreshed when the source changes.
+---
+## 44. X Might Sound Simple, But
+**What it is:** Setup that claims simplicity hides complexity.
+**Why AI may reach for it:** The setup creates a small suspense gap: the idea looks simple, but the model promises hidden difficulty. It can inflate an ordinary instruction without showing what makes it hard.
+**Three typical AI examples:**
+- “This might sound simple, but most teams never do it.”
+- “Brand clarity might sound simple, but it’s brutally hard.”
+- “Following up might sound simple, but it’s where deals are won.”
+**How to spot it:** Find “might sound simple, but.” Ask for the actual obstacle, failure rate, or counterexample in the next sentence; if none appears, state the instruction without suspense.
+**The ugly version:** This might sound simple, but simplicity is incredibly complex, and the simple act of keeping things simple is often the hardest complexity of all.
+**Exception:** Use the setup when a documented obstacle genuinely contradicts the apparent simplicity.
+**Good use:** The repair sounds simple, but the casing contains a charged capacitor that remains dangerous after unplugging.
+---
+## 45. X Is More Than Just Y
+**What it is:** Expansion move claiming additional layers.
+**Why AI may reach for it:** The construction enlarges a concept by rejecting a narrow version and attaching a grander one. It can confuse an additional component with the whole definition.
+**Three typical AI examples:**
+- “Trust is more than just delivering on time; it’s how you handle the misses.”
+- “Brand is more than just visuals; it’s behavior.”
+- “Strategy is more than just goals; it’s trade-offs.”
+**How to spot it:** Search for “more than just.” Check whether Y is a common but incomplete understanding and whether the added component is specific, distinct, and supported; otherwise use “also.”
+**The ugly version:** Marketing is more than just marketing; it is culture, identity, purpose, belonging, transformation, and the boundless human story behind everything.
+**Exception:** Use it when correcting a documented narrow definition with a concrete additional component.
+**Good use:** The migration is more than just copying files; we must preserve permissions and audit history.
+---
+## 46. In Fact
+**What it is:** Mild intensifier used excessively in AI text.
+**Why AI may reach for it:** “In fact” lets the model upgrade the certainty of the next sentence without supplying a fact. It can turn a preference or generalization into evidence by tone alone.
+**Three typical AI examples:**
+- “In fact, most audiences don’t remember more than one thing about you.”
+- “In fact, your offer matters more than your funnel.”
+- “In fact, doing less often gets you more.”
+**How to spot it:** Find “in fact” and classify what follows as measured fact, sourced correction, inference, or opinion. If it is not a fact or correction, remove the intensifier.
+**The ugly version:** In fact, authenticity is always the strongest strategy. In fact, everyone knows this. In fact, the facts speak for themselves.
+**Exception:** Use it when the next sentence corrects a misconception or supplies stronger evidence.
+**Good use:** We expected demand to fall. In fact, paid orders rose from 412 to 587.
+---
+## 47. For Example
+**What it is:** Generic lead-in to often generic examples.
+**Why AI may reach for it:** The phrase is a reliable way for the model to make an abstract claim look supported. The example may remain hypothetical, generic, or unrelated to the category.
+**Three typical AI examples:**
+- “For example, you might reposition from ‘design services’ to ‘conversion-focused design.’”
+- “For example, instead of ‘we’re innovative,’ show the process you use.”
+- “For example, send a pattern-breaking email to re-engage cold subscribers.”
+**How to spot it:** Mark every “for example.” Test whether the instance is real or clearly hypothetical, belongs to the stated category, and makes the rule more concrete; if not, remove or replace it.
+**The ugly version:** Strong brands create emotion. For example, imagine a powerful brand that creates a strong emotional feeling for its audience.
+**Exception:** Use it when an instance materially clarifies an abstract category or rule.
+**Good use:** Some expenses vary with usage. For example, our SMS bill rises by £0.04 for each message sent.
+---
+## 48. For Instance
+**What it is:** Near-duplicate of “for example,” adding redundancy.
+**Why AI may reach for it:** “For instance” performs the same support function as “for example” and is easy to repeat across paragraphs. It can disguise invented illustrations as evidence.
+**Three typical AI examples:**
+- “For instance, a founder-led brand feels different from a faceless logo.”
+- “For instance, you can raise prices while adding constraints, not features.”
+- “For instance, use a simple one-sentence promise across all channels.”
+**How to spot it:** Search for “for instance” and verify the instance against the claim, source, and category. If it is a vague possibility rather than an informative case, cut it.
+**The ugly version:** Clarity matters in every context. For instance, a clear thing is easier to understand than an unclear thing in almost any situation.
+**Exception:** Use it sparingly when the reader needs a concrete instance to understand the category.
+**Good use:** The policy covers irreversible actions. For instance, deleting the encryption key requires a second approver.
+---
+## 49. From a Broader Perspective
+**What it is:** Zoom-out framing for high-level commentary.
+**Why AI may reach for it:** The zoom-out phrase lets the model raise the abstraction level and sound strategic. It may change the vocabulary without changing the unit of analysis.
+**Three typical AI examples:**
+- “From a broader perspective, churn is a lagging indicator of broken trust.”
+- “From a broader perspective, your brand is the accumulation of tiny touchpoints.”
+- “From a broader perspective, metrics are just a proxy for behavior.”
+**How to spot it:** Find “from a broader perspective.” Name the old and new timeframe, population, or system boundary; if no level actually changes, remove the phrase.
+**The ugly version:** From a broader perspective, the broader picture reveals a more holistic perspective on the broad strategic landscape as a whole.
+**Exception:** Use it when the analysis explicitly changes scale and the new scale reveals something relevant.
+**Good use:** From a broader perspective, the five delayed orders are part of a 23% rise in regional delivery failures this quarter.
+---
+## 50. Zooming In / Zooming Out
+**What it is:** Camera-metaphor language about shifting levels of detail.
+**Why AI may reach for it:** Camera language gives the model an easy transition between detail and overview. It can imply analysis without naming the actual scale or evidence.
+**Three typical AI examples:**
+- “Zooming out, the real story is your positioning.”
+- “Zooming in, your subject lines are doing the heavy lifting.”
+- “Zooming out, your category is overcrowded; zooming in, your story is not.”
+**How to spot it:** Search for “zooming in” and “zooming out.” Replace each with the precise level being examined; if the sentence cannot name that level, the camera move is decorative.
+**The ugly version:** Zooming out, we see the big picture. Zooming in, we see the details. Zooming back out, those details form a picture. Zooming in again, the picture has details.
+**Exception:** Use the metaphor when deliberately switching between defined aggregate and detailed evidence.
+**Good use:** Zooming out to the full quarter, cancellations are flat; zooming in to the final week, they doubled after the price change.
+---
+## 51. In Summary
+**What it is:** Formal wrap-up phrase that signals the end.
+**Why AI may reach for it:** A formal summary cue gives the model a standard ending and permission to repeat itself. The label can make a slogan feel like a synthesis.
+**Three typical AI examples:**
+- “In summary, clarity, consistency, and compounding are your leverage.”
+- “In summary, your brand is a promise, and your marketing is proof.”
+- “In summary, attention is rented, but trust is owned.”
+**How to spot it:** Find “in summary” and compare the following text with the preceding section. Keep it only if it compresses a long argument, preserves the key qualification, and helps retrieval.
+**The ugly version:** In summary, to summarize the summary, the main takeaway from everything summarized above is that the key points are important to remember.
+**Exception:** Use a summary after long or technical material when readers need a shorter retrieval layer.
+**Good use:** In summary, the treatment reduced symptoms for six weeks, caused more nausea, and has not been tested beyond three months.
+---
+## 52. To Recap
+**What it is:** Casual recap signal that often repeats earlier bullets.
+**Why AI may reach for it:** “To recap” lets the model replay recent bullets and maintain the appearance of structure. It often repeats material the reader has not had time to forget.
+**Three typical AI examples:**
+- “To recap, know who you serve, what you promise, and how you prove it.”
+- “To recap, simplify your offer, shrink your scope, sharpen your story.”
+- “To recap, design for trust, not just for aesthetics.”
+**How to spot it:** Search for “to recap” and measure the distance from the original points. If the recap follows immediately or adds no compression, delete it.
+**The ugly version:** To recap the recap: first, remember the first point; second, remember the second point; and third, remember that these were the three points we just covered.
+**Exception:** Use a recap after a long interruption or multi-stage discussion when restoring context prevents error.
+**Good use:** To recap before we reconnect the supply: valve A is closed, valve B is locked, and the pressure gauge reads zero.
+---
+## 53. It Depends, But
+**What it is:** Non-committal answer that defaults to “it depends” followed by generic factors.
+**Why AI may reach for it:** “It depends” protects the model from committing, while “but” lets it continue with generic advice anyway. The variables may be listed without showing how they change the answer.
+**Three typical AI examples:**
+- “It depends, but start by clarifying who you actually want to reach.”
+- “It depends, but look at your margins, goals, and risk tolerance.”
+- “It depends, but consider your audience size and sales cycle.”
+**How to spot it:** Find “it depends, but.” Require named variables, decision thresholds, and a default; if changing the variables would not change the advice, the hedge is empty.
+**The ugly version:** It depends, but generally you should consider your goals, audience, context, budget, preferences, timing, needs, and whatever feels right for your unique situation.
+**Exception:** Use it when the outcome truly changes with named variables and the text explains those branches.
+**Good use:** It depends on monthly volume: below 10,000 requests, Plan A is cheaper; above that, Plan B is.
+---
+## 54. No One-Size-Fits-All
+**What it is:** Truism that denies universality right after giving broad advice.
+**Why AI may reach for it:** The truism lets the model disclaim universality after giving universal advice. It sounds nuanced without providing a rule for choosing among alternatives.
+**Three typical AI examples:**
+- “There’s no one-size-fits-all strategy, but principles travel well.”
+- “There’s no one-size-fits-all pricing model.”
+- “There’s no one-size-fits-all content cadence.”
+**How to spot it:** Search for “no one-size-fits-all.” Ask which variables create different fits and what each reader should do with them; if no branches follow, the caveat is decorative.
+**The ugly version:** There is no one-size-fits-all solution, which is why this universally applicable framework works for every business, audience, goal, and stage.
+**Exception:** Use the phrase when the text immediately names the variables and gives different decision rules.
+**Good use:** There is no one-size-fits-all dose: the prescriber adjusts it for age, kidney function, and the medicines listed below.
+---
+## 55. Tailor It to Your Needs
+**What it is:** Personalized-sounding but generic customization advice.
+**Why AI may reach for it:** The instruction simulates personalization while leaving every decision to the reader. The model avoids naming what can change and what evidence should guide the change.
+**Three typical AI examples:**
+- “Always tailor these frameworks to your specific context.”
+- “Tailor this template to your audience and voice.”
+- “Tailor the cadence to your bandwidth and goals.”
+**How to spot it:** Find “tailor it to your needs.” Ask which fields, thresholds, or steps may change, which must stay fixed, and what input controls the choice; if none are named, the advice is empty.
+**The ugly version:** Use this exact universal template, then tailor every part to your unique needs, goals, voice, audience, context, preferences, and whatever else makes it work for you.
+**Exception:** Use customization advice when the adjustable parts, fixed constraints, and decision evidence are named.
+**Good use:** Tailor the reminder interval to the customer’s billing cycle, but keep the legal notice unchanged.
+---
+## 56. Start Small and Iterate
+**What it is:** Safe incrementalism advice, regardless of domain.
+**Why AI may reach for it:** Incrementalism is a safe recommendation because it sounds prudent across almost any domain. The model can prescribe testing without naming the risk, hypothesis, or signal.
+**Three typical AI examples:**
+- “Start small, test one channel, then iterate.”
+- “Start small: one offer, one audience, one channel.”
+- “Start small, gather feedback, and iterate based on signal.”
+**How to spot it:** Search for “start small and iterate.” Require a bounded first test, a measurement, a review date, and a rule for changing course; without those, “iterate” means nothing.
+**The ugly version:** Start small, iterate quickly, learn continuously, improve constantly, and keep iterating on your iterations until iterative success emerges.
+**Exception:** Use the advice for a reversible experiment with a defined hypothesis and stopping rule.
+**Good use:** Start small with 5% of traffic, then iterate only if checkout errors stay below 0.5% for 24 hours.
+---
+## 57. X, Y, and Z Triads
+**What it is:** Lists of three for rhythm, often with vague adjectives.
+**Why AI may reach for it:** Three items give the model a pleasing cadence and a natural stopping point. It may invent or pad a third item to complete the rhythm.
+**Three typical AI examples:**
+- “Make it simple, useful, and memorable.”
+- “You want it to feel intentional, consistent, and trustworthy.”
+- “Your brand should be relevant, differentiated, and credible.”
+**How to spot it:** Mark repeated triples in sentences, headings, and lists. Remove or add one item; if the logic is unchanged, or one member overlaps another, the count was chosen for cadence.
+**The ugly version:** Our bold, brave, brilliant framework makes brands clear, compelling, credible through strategy, storytelling, and strategic storytelling.
+**Exception:** Use a triad when the subject genuinely has three parallel, distinct parts.
+**Good use:** The incident review covers detection, containment, and recovery.
+---
+## 58. Beginner to Expert Range
+**What it is:** Overly broad audience claim that spans all skill levels.
+**Why AI may reach for it:** A beginner-to-expert range makes the audience sound broad and the content universally useful. It avoids choosing the prior knowledge the explanation assumes.
+**Three typical AI examples:**
+- “Whether you’re a beginner or an expert, these ideas apply.”
+- “Useful whether you’re early-stage or scaling.”
+- “Helpful whether you’re new to branding or have years of experience.”
+**How to spot it:** Look for claims that one section serves beginners and experts alike. Compare the prerequisites and actions for both groups; if they are identical or neither is named, choose an audience or split the guidance.
+**The ugly version:** Whether you have never opened a spreadsheet or have spent thirty years building financial models, these three basic-yet-advanced tips will transform your analysis.
+**Exception:** Use the range when the content provides explicit paths for each skill level.
+**Good use:** Whether you’re a beginner or an expert, choose the matching path: beginners complete the formula exercise; experts start with the audit case on page 12.
+---
+## 59. No Matter Where You Are on Your Journey
+**What it is:** Journey metaphor that covers every stage.
+**Why AI may reach for it:** The journey frame lets the model address everyone without defining stages. It turns a process into emotional progress and attaches the same advice to every point.
+**Three typical AI examples:**
+- “No matter where you are on your journey, clarity helps.”
+- “No matter where you are on your journey, audience obsession wins.”
+- “No matter where you are on your journey, trust is the constraint.”
+**How to spot it:** Search for “no matter where you are on your journey.” Ask what the stages are and how the action changes at each one; if it does not change, remove the journey claim.
+**The ugly version:** No matter where you are on your unique journey through the journey of growth, this timeless guidance will meet you exactly where your journey happens to be.
+---
+## 60. Take It to the Next Level
+**What it is:** Vague promise of improvement without specifics.
+**Why AI may reach for it:** “Next level” promises improvement without forcing the model to define the current level or the result. The upward motion supplies ambition in place of a metric.
+**Three typical AI examples:**
+- “Use these tactics to take your content to the next level.”
+- “This mindset shift takes your brand to the next level.”
+- “A simple system can take your execution to the next level.”
+**How to spot it:** Find “take X to the next level.” Ask for the baseline, target, measure, and timeframe; if no level can be identified, replace the phrase with the concrete change.
+**The ugly version:** Take your already elevated brand to the next level beyond the next level with next-level strategies designed for truly next-level growth.
+---
+# Patterns 61–80
+## 61. Unlock the Power of X
+**What it is:** Marketing-style invitation to “unlock” benefits.
+**Why AI may reach for it:** “Unlock” frames an ordinary use as releasing hidden value. It lets the model promise a broad benefit without naming the mechanism, constraint, or size of the effect.
+**Three typical AI examples:**
+- “Unlock the power of storytelling in your sales process.”
+- “Unlock the power of testimonials in your funnel.”
+- “Unlock the power of positioning to escape price wars.”
+**How to spot it:** Search for “unlock the power of.” Replace it with the actor, action, and result; if the sentence cannot say what changes or by how much, the locked-power metaphor is empty.
+**The ugly version:** Unlock the limitless power of powerful storytelling to unlock your audience’s untapped potential and open the door to unprecedented growth.
+---
+## 62. Harness the Power of X
+**What it is:** Similar to “unlock,” overusing verbs like “harness” that AI favors.
+**Why AI may reach for it:** “Harness” gives the model a high-energy verb for using any tool or idea. The phrase implies control over a force while avoiding the concrete operation.
+**Three typical AI examples:**
+- “Harness the power of constraints to ship faster.”
+- “Harness the power of focus to build a sharper brand.”
+- “Harness the power of email to deepen relationships.”
+**How to spot it:** Find “harness the power of.” Ask what is being captured, by which action, under what constraint, and toward which result; if those details are absent, use the actual verb.
+**The ugly version:** Harness the power of focus to harness the power of clarity, then harness both powers to powerfully harness growth.
+---
+## 63. Delve Into / Delving Into
+**What it is:** Over-formal verb heavily associated with AI text.
+**Why AI may reach for it:** “Delve” is a probable continuation in formal explanatory prose and gives a topic artificial depth. The model can choose it where “examine,” “read,” or “analyse” would name the work better.
+**Three typical AI examples:**
+- “Let’s delve into why most positioning advice fails.”
+- “This post delves into the psychology behind pricing.”
+- “Delving into your churn data reveals hidden patterns.”
+**How to spot it:** Search for “delve,” “delves,” and “delving.” Replace each with the literal action; if the replacement is clearer and loses no meaning, the formal verb was ornamental.
+**The ugly version:** This article delves deeply into the deep intricacies we must delve into before delving even deeper into what lies beneath.
+**Exception:** The verb can be natural in formal prose when it describes sustained investigation rather than decorating a routine overview.
+**Good use:** The biography delves into correspondence that earlier accounts ignored.
+---
+## 64. Dive Into the Intricacies Of
+**What it is:** Wordier cousin of “dive into,” often paired with “intricacies.”
+**Why AI may reach for it:** The phrase stacks two depth signals—“dive” and “intricacies”—so the model can make a broad overview sound rigorous. It promises detail before naming any complex relationship.
+**Three typical AI examples:**
+- “Let’s dive into the intricacies of customer retention.”
+- “This guide dives into the intricacies of brand architecture.”
+- “We’ll dive into the intricacies of growth loops.”
+**How to spot it:** Search for “dive into the intricacies of.” List the actual interacting parts or difficult distinctions; if none follow, replace the promise with the subject.
+**The ugly version:** Let’s dive deep into the intricate intricacies of a deeply intricate topic whose many intricacies demand an even deeper dive.
+---
+## 65. Navigate the Complex Landscape
+**What it is:** Navigation metaphor with “complex landscape” or “landscape of X.”
+**Why AI may reach for it:** The navigation-and-landscape pair is a ready-made metaphor for any difficult field. It lets the model claim complexity without naming the choices, hazards, or route.
+**Three typical AI examples:**
+- “Navigate the complex landscape of modern marketing.”
+- “Navigate the complex landscape of AI tools.”
+- “Navigate the complex landscape of fundraising.”
+**How to spot it:** Search for “navigate the complex landscape of.” Replace the landscape with the actual system and identify the decision being navigated; if the sentence still lacks a route or constraint, delete the metaphor.
+**The ugly version:** Navigate the complex, ever-shifting landscape of modern complexity with a trusted roadmap, clear compass, and guiding North Star.
+---
+## 66. In Conclusion
+**What it is:** School-essay-style closer.
+**Why AI may reach for it:** The phrase is a learned school-essay ending that tells the model and reader the response is closing. It often precedes one more generic thesis restatement.
+**Three typical AI examples:**
+- “In conclusion, trust is the real growth engine.”
+- “In conclusion, strategy is about saying no.”
+- “In conclusion, the brands that win are the ones that choose.”
+**How to spot it:** Find “in conclusion.” Check whether the final paragraph synthesizes a long argument or merely repeats the opening claim; in short pieces, remove the label and keep any useful conclusion.
+**The ugly version:** In conclusion, to conclude this conclusion, the conclusion is that strong conclusions conclusively bring everything to a meaningful conclusion.
+**Exception:** Use the marker when a formal genre expects an explicitly signposted conclusion after a substantial argument.
+**Good use:** In conclusion, the three trials show a short-term benefit, but the evidence is too small and too brief to support routine use.
+---
+## 67. Remember That
+**What it is:** Instructional reminder phrase used excessively.
+**Why AI may reach for it:** The imperative lets the model elevate the next statement into a durable lesson. Repeating it can make ordinary claims sound like rules the reader is in danger of forgetting.
+**Three typical AI examples:**
+- “Remember that people buy outcomes, not features.”
+- “Remember that your audience is scrolling, not studying.”
+- “Remember that every touchpoint teaches them how to feel about you.”
+**How to spot it:** Search for “remember that.” Ask where the condition was introduced, why it matters now, and what action changes; if there is no earlier condition or consequence, state the fact directly.
+**The ugly version:** Remember that you must always remember the importance of remembering what truly matters, because forgetting to remember can make you forget.
+**Exception:** Use a reminder when an earlier condition materially affects the current step.
+**Good use:** Remember that the sample contains live customer data; use the encrypted drive when you copy it.
+---
+## 68. Keep in Mind That
+**What it is:** Slight variation on “remember that,” with similar tone.
+**Why AI may reach for it:** “Keep in mind” gives the model a soft warning slot that can accept almost any caveat. It sounds considerate even when the limitation is vague or unrelated.
+**Three typical AI examples:**
+- “Keep in mind that positioning happens with or without your intent.”
+- “Keep in mind that more traffic doesn’t fix a broken offer.”
+- “Keep in mind that consistency compounds quietly.”
+**How to spot it:** Mark “keep in mind that.” Name the exact decision or sentence it qualifies; if the caveat could be pasted anywhere, move the real condition beside the affected claim or delete it.
+**The ugly version:** Keep in mind that everything depends on context, and also keep in mind that context itself depends on many things you should continue keeping in mind.
+**Exception:** Use it conversationally when a previously stated condition must remain active during the next instruction.
+**Good use:** Keep in mind that the figures exclude refunds when you compare them with last month’s total.
+---
+## 69. It’s Worth Noting That
+**What it is:** Hedge that adds polite distance from the claim.
+**Why AI may reach for it:** The phrase creates polite distance and mild importance without committing to either. It can bury a necessary condition as an aside.
+**Three typical AI examples:**
+- “It’s worth noting that virality doesn’t guarantee profit.”
+- “It’s worth noting that discounts train people to wait.”
+- “It’s worth noting that ‘best’ is context-dependent.”
+**How to spot it:** Find “it’s worth noting that.” Decide whether the point is necessary, optional, or unsupported; state necessary limits directly, move optional context to a note, and delete unsupported observations.
+**The ugly version:** It’s worth noting that there are many noteworthy factors worth considering, although it is also worth noting that not every noteworthy factor can be noted here.
+**Exception:** Use it sparingly for relevant secondary context that does not change the main instruction.
+**Good use:** It’s worth noting that the archive uses local time, while every timestamp in this report is UTC.
+---
+## 70. From X to Y: Subtitle Pattern
+**What it is:** Title or heading format “From X to Y: Z” signaling a journey.
+**Why AI may reach for it:** The from-to subtitle gives the model an instant transformation story and a balanced headline shape. It can imply that the material carries readers between two states without showing the path.
+**Three typical AI examples:**
+- “From Confusion to Clarity: A Simple Positioning Framework.”
+- “From Followers to Fans: Turning Attention into Affinity.”
+- “From Ideas to Income: Productizing Your Expertise.”
+**How to spot it:** Look for titles shaped “From X to Y: Z.” Check whether X and Y are defined states, the content supplies the transition, and Z names the method; if not, use a literal title.
+**The ugly version:** From Invisible to Unstoppable: From Confusion to Clarity on the Transformational Journey from Ideas to Infinite Impact.
+**Exception:** Use the format when the material genuinely documents a defined change from one state to another.
+**Good use:** From 14 Minutes to 6: How We Cut Checkout Time by Removing Manual Approval.
+---
+## 71. The X You Didn’t Know You Needed
+**What it is:** Clickbait framing of unexpected value.
+**Why AI may reach for it:** The construction manufactures surprise and need in the same line. The model can tell readers they were missing something before showing evidence that the thing matters.
+**Three typical AI examples:**
+- “The positioning exercise you didn’t know you needed.”
+- “The onboarding email you didn’t know you needed.”
+- “The constraint you didn’t know you needed.”
+**How to spot it:** Search for “you didn’t know you needed.” Ask what observed problem the item solves and why the audience would not already recognize it; if the need is invented, state the benefit plainly.
+**The ugly version:** The revolutionary framework you didn’t know you needed for the problem you didn’t know you had and the transformation you never knew was possible.
+---
+## 72. Here’s the Thing
+**What it is:** Conversational pivot that pretends to cut through noise.
+**Why AI may reach for it:** The conversational pivot lets the model perform candour before a familiar point. It signals that noise is being cut through even when no correction or new fact follows.
+**Three typical AI examples:**
+- “Here’s the thing: people don’t read, they skim.”
+- “Here’s the thing: most brands sound the same.”
+- “Here’s the thing: distribution beats craftsmanship in the short term.”
+**How to spot it:** Find “here’s the thing.” Remove it and inspect the next sentence; if the sentence is a platitude, repetition, or unsupported universal, the pivot supplied all the force.
+**The ugly version:** Here’s the thing about the thing: the real thing is not the thing you think it is, and that is the thing most people miss.
+**Exception:** It can work in spoken or deliberately conversational prose when it marks a real correction or direct answer.
+**Good use:** Here’s the thing: I gave you the wrong deadline. The application closes today at five.
+---
+## 73. Spoiler: It’s Not X
+**What it is:** “Spoiler” framing that reveals a non-obvious answer, usually still obvious.
+**Why AI may reach for it:** “Spoiler” creates a reveal beat, while the not-X frame supplies an instant correction. The model gets suspense and certainty without proving that the answer is surprising.
+**Three typical AI examples:**
+- “Spoiler: it’s not your logo, it’s your promise.”
+- “Spoiler: the algorithm isn’t your biggest problem.”
+- “Spoiler: you don’t need more tools; you need more conviction.”
+**How to spot it:** Search for “spoiler” followed by a negation or reveal. Ask whether there is an actual plot/result to protect and whether the conclusion is non-obvious; if not, state it directly.
+**The ugly version:** Spoiler: it’s not your strategy. Bigger spoiler: it’s not your tactics. Ultimate spoiler: the real answer was authentic consistency all along.
+**Exception:** Use a spoiler label when discussing a story, competition, or result that readers may reasonably want to encounter unannounced.
+**Good use:** Spoiler: it’s not the butler; the final chapter reveals that Mara forged the letter.
+---
+## 74. If You’ve Ever Felt X, You’re Not Alone
+**What it is:** Empathy opener that generalizes a feeling.
+**Why AI may reach for it:** The opener lets the model infer a common pain, validate it, and create instant solidarity. It can claim “you’re not alone” without evidence that the reader feels this way or that others share it.
+**Three typical AI examples:**
+- “If you’ve ever felt stuck staring at a blank page, you’re not alone.”
+- “If you’ve ever felt like your brand is invisible, you’re not alone.”
+- “If you’ve ever felt guilty about not posting daily, you’re not alone.”
+**How to spot it:** Look for “if you’ve ever felt X, you’re not alone.” Require direct audience evidence for both the feeling and its prevalence; if the writer has neither, describe the situation without assigning emotion.
+**The ugly version:** If you’ve ever felt lost, stuck, invisible, overwhelmed, underwhelmed, behind, ahead, or somewhere in between, you’re not alone—and this message was made for you.
+**Exception:** Use the reassurance when the audience has directly reported the feeling and reliable evidence shows it is shared.
+**Good use:** If you felt disoriented during the first week, you’re not alone: 38 of 52 new starters reported the same problem in our onboarding survey.
+---
+## 75. Chances Are
+**What it is:** Probabilistic hedge to make assumptions about the reader.
+**Why AI may reach for it:** ‘Chances are’ lets the model turn an unverified guess about the reader into a plausible-sounding probability. It creates intimacy without requiring audience data.
+**Three typical AI examples:**
+- “Chances are, you’re leaving attention on the table.”
+- “Chances are, your positioning is too broad.”
+- “Chances are, your best customers are already telling you what to say.”
+**How to spot it:** Look for ‘chances are’ followed by a claim about what the reader does, wants, or gets wrong. Ask what sample supports the probability. Falsify the flag when the writer cites representative data or clearly labels the sentence as a hypothesis to test.
+**The ugly version:** Chances are, your team is wasting its best ideas, your customers are losing patience, and your competitors have already noticed—even though nobody has looked at the usage data yet.
+**Exception:** Use probabilistic language when a named dataset supports it and the wording matches the measured rate.
+**Good use:** In 68% of the 412 support tickets reviewed, the customer had already tried resetting the password, so chances are the next caller has tried it too.
+---
+## 76. More Often Than Not
+**What it is:** Another probability hedge to sound measured.
+**Why AI may reach for it:** ‘More often than not’ supplies the tone of a measured generalization while leaving the frequency undefined. The model can sound empirical without committing to a denominator.
+**Three typical AI examples:**
+- “More often than not, the problem is clarity, not channels.”
+- “More often than not, churn is a symptom of misaligned expectations.”
+- “More often than not, your first idea isn’t the one that works.”
+**How to spot it:** Search for ‘more often than not’ and check whether the sentence names a population, period, and count. Falsify the flag when the underlying observations genuinely exceed half and the writer can show how they were counted.
+**The ugly version:** More often than not, weak growth comes from weak positioning, and more often than not, weak positioning comes from weak courage, which is more often than not the real problem.
+**Exception:** Keep it when the claim summarizes a documented majority and an exact percentage would distract from the point.
+**Good use:** Across our last 30 incident reviews, more often than not the first alert came from a customer rather than monitoring: 19 cases versus 11.
+---
+## 77. At First Glance
+**What it is:** Contrast between superficial and deeper view.
+**Why AI may reach for it:** ‘At first glance’ manufactures a shallow-versus-deep reveal before the model has established that two interpretations exist. It gives ordinary analysis a discovery arc.
+**Three typical AI examples:**
+- “At first glance, it looks like a pricing issue.”
+- “At first glance, this seems like a lead problem.”
+- “At first glance, the campaign looks like a failure.”
+**How to spot it:** Look for ‘at first glance’ followed later by ‘but,’ ‘however,’ ‘on closer inspection,’ or a hidden cause. Falsify the flag when the first interpretation is genuinely reasonable from the available evidence and the second is supported by additional evidence.
+**The ugly version:** At first glance, the falling conversion rate looked like a button problem; on closer inspection, it revealed a profound crisis of trust hiding beneath every pixel.
+**Exception:** Use it when the text compares two evidence states and explains what new observation changed the interpretation.
+**Good use:** At first glance, the outage looked regional because only EU dashboards were red. Packet captures later showed that all regions were dropping the same authentication calls.
+---
+## 78. Behind the Scenes
+**What it is:** Framing that claims to reveal hidden dynamics.
+**Why AI may reach for it:** ‘Behind the scenes’ promises privileged access to concealed work. The phrase can make routine operations feel secret or consequential without explaining what actually happens.
+**Three typical AI examples:**
+- “Behind the scenes, the real work is happening in your CRM.”
+- “Behind the scenes, your onboarding shapes long-term retention.”
+- “Behind the scenes, your ops decide how your brand feels.”
+**How to spot it:** Search for ‘behind the scenes,’ ‘what you do not see,’ or ‘under the hood,’ then identify the supposedly hidden actor, process, and effect. Falsify the flag when the passage reveals concrete internal steps that the audience could not otherwise observe.
+**The ugly version:** Behind the scenes, an invisible orchestra of workflows quietly synchronizes every touchpoint, ensuring the magic reaches customers without them ever seeing the machinery.
+**Exception:** Use it to introduce specific internal operations that are relevant and normally invisible to the reader.
+**Good use:** Behind the scenes, the upload service splits the video into six-second segments, stores two copies, and waits for both checksums before marking the file ready.
+---
+## 79. Self-Referential Restatement of the Question
+**What it is:** Opening that mirrors the user’s question back at them.
+**Why AI may reach for it:** Restating the question buys the model time and creates the appearance of alignment. It often mirrors the user’s nouns before supplying any answer or resolving any ambiguity.
+**Three typical AI examples:**
+- “You asked how to build a memorable brand, so let’s walk through it.”
+- “You want to know whether to niche down; here’s a breakdown.”
+- “You’re wondering how to monetize your audience; here’s the playbook.”
+**How to spot it:** Compare the opening sentence with the prompt. Literal reuse of the same question, second-person desire, or ‘you asked’ framing is the cue. Falsify the flag when the restatement narrows an ambiguous term, confirms a constraint, or corrects a consequential misunderstanding.
+**The ugly version:** You asked how to reduce churn, which means you want to know how to stop customers from leaving, so let us examine how a business can retain the customers it already has.
+**Exception:** Restate only when doing so confirms a consequential interpretation or converts a broad request into a precise question.
+**Good use:** You asked for ‘retention.’ I am treating that as 90-day paid-account retention, not email-list retention, because the two require different data.
+---
+## 80. Let’s Explore
+**What it is:** Vague invitation to examine a topic.
+**Why AI may reach for it:** ‘Let’s explore’ is a low-commitment bridge that lets the model begin another section without stating its claim, method, or destination. It signals motion while postponing substance.
+**Three typical AI examples:**
+- “Let’s explore why most positioning work fails.”
+- “Let’s explore the difference between reach and resonance.”
+- “Let’s explore how brand and performance marketing intersect.”
+**How to spot it:** Look for ‘let’s explore,’ ‘let’s take a look,’ or ‘let’s examine’ immediately before a heading or explanation. Remove the invitation and read the next sentence. Falsify the flag when the invitation is part of a real collaborative exercise with a defined object and stopping point.
+**The ugly version:** Let’s explore the fascinating intersection of strategy, creativity, and growth as we uncover the many ways these powerful forces come together.
+---
+# Patterns 81–100
+## 81. Overly Balanced On the Other Hand Clause
+**What it is:** Adds a second clause to neutralize any strong statement.
+**Why AI may reach for it:** An automatic ‘on the other hand’ clause protects the model from sounding one-sided. It can invent symmetry between considerations that differ sharply in evidence, likelihood, or importance.
+**Three typical AI examples:**
+- “Brand matters more than performance, but on the other hand, you still need conversions to survive.”
+- “Raising prices can boost margins, but on the other hand, it may alienate price-sensitive customers.”
+- “Daily content can accelerate learning, but on the other hand, it can burn you out.”
+**How to spot it:** Mark paired clauses introduced by ‘on the one hand’ and ‘on the other hand,’ especially when both receive equal space. Compare their evidence and decision weight. Falsify the flag when both sides are material, supported, and necessary to the decision.
+**The ugly version:** On the one hand, encrypting customer passwords prevents catastrophic exposure; on the other hand, skipping encryption could make development slightly faster, so both approaches deserve careful consideration.
+**Exception:** Use balanced clauses when two supported considerations create a real trade-off and their relative weight is made explicit.
+**Good use:** On the one hand, the annual contract cuts the price by 18%. On the other, it locks us in before the security review is complete; that unresolved risk outweighs the discount.
+---
+## 82. Formal Academic Verbs Cluster
+**What it is:** Overuse of verbs like “underscore,” “illuminate,” “facilitate,” and “bolster.”
+**Why AI may reach for it:** Formal verbs such as ‘underscore,’ ‘illuminate,’ ‘facilitate,’ and ‘bolster’ let the model raise the register without adding a clearer action. A cluster makes basic relationships sound scholarly.
+**Three typical AI examples:**
+- “These examples underscore the importance of clear positioning.”
+- “This case study illuminates how trust compounds.”
+- “A simple system facilitates better decisions.”
+**How to spot it:** Circle Latinate verbs including ‘underscore,’ ‘illuminate,’ ‘facilitate,’ ‘bolster,’ ‘elucidate,’ and ‘demonstrate.’ Replace each with the literal action and compare precision. Falsify the flag when the verb names the exact evidentiary relationship expected in the genre.
+**The ugly version:** The findings illuminate the mechanisms that facilitate adoption, bolster confidence, and underscore the pivotal significance of strategically optimized communication.
+**Exception:** Formal verbs are appropriate when they express a precise relationship in academic, legal, or technical prose rather than merely raising the tone.
+**Good use:** The second experiment bolsters the causal claim because it reproduces the effect after random assignment.
+---
+## 83. Transform Your X
+**What it is:** Marketing verb “transform” applied to vague outcomes.
+**Why AI may reach for it:** ‘Transform’ compresses an unspecified before-and-after change into one promotional verb. The model can promise a dramatic outcome without naming the baseline, intervention, or result.
+**Three typical AI examples:**
+- “Transform your brand with a clear, simple promise.”
+- “Transform your onboarding with one thoughtful email.”
+- “Transform your content from noise to signal.”
+**How to spot it:** Search for ‘transform’ or ‘transformative’ attached to a broad noun such as business, workflow, brand, or experience. Demand a before state, after state, and mechanism. Falsify the flag when all three are concrete and the change is genuinely substantial.
+**The ugly version:** Transform your entire business with one remarkably simple dashboard that turns scattered data into limitless clarity, confidence, and growth.
+**Exception:** Use ‘transform’ for a documented, material change whose starting state, mechanism, and resulting state are all shown.
+**Good use:** The screen reader transformed the task from one the employee could not complete alone into a five-minute self-service process.
+---
+## 84. X Isn’t a Destination; It’s a Journey
+**What it is:** Journey cliché applied to almost any topic.
+**Why AI may reach for it:** The destination-versus-journey contrast gives any ongoing activity instant wisdom. It replaces the specific cycles, setbacks, or maintenance work with a familiar moral.
+**Three typical AI examples:**
+- “Brand isn’t a destination; it’s a journey.”
+- “Learning isn’t a destination; it’s a journey.”
+- “Product–market fit isn’t a destination; it’s a journey.”
+**How to spot it:** Look for ‘isn’t a destination; it’s a journey’ or close destination/path contrasts. Translate the metaphor into literal process language. Falsify the flag when the passage sustains the journey metaphor and maps its parts to a real sequence rather than stopping at the cliché.
+**The ugly version:** Security is not a destination; it is an endless journey down a winding road where every milestone simply reveals another horizon.
+---
+## 85. At Scale
+**What it is:** Jargon phrase bolted onto claims to make them sound bigger.
+**Why AI may reach for it:** Adding ‘at scale’ makes a claim sound operationally mature while leaving volume, frequency, geography, and constraints undefined. It borrows the authority of systems engineering.
+**Three typical AI examples:**
+- “You need a way to tell your story at scale.”
+- “Automation lets you deliver personalization at scale.”
+- “Trust doesn’t happen at scale without proof.”
+**How to spot it:** Search for ‘at scale,’ ‘scaled,’ or ‘scalable’ and ask: how many users, requests, locations, or repetitions over what period? Falsify the flag when the scale is quantified and the mechanism addresses the bottleneck created by that volume.
+**The ugly version:** Our platform delivers authentic, one-to-one human connection at unprecedented scale to everyone, everywhere, all at once.
+**Exception:** Use the phrase when scale is quantified and materially changes the engineering or operating method.
+**Good use:** Manual review works for 40 invoices a day; at 18,000 a day, we need queued validation and exception sampling.
+---
+## 86. From X to Y, Everyone Can Z
+**What it is:** Inclusive statement that tries to cover all experience levels.
+**Why AI may reach for it:** A ‘from X to Y, everyone’ frame stretches the audience until nearly anyone fits. The model avoids choosing a reader and implies universal usefulness without testing distinct needs.
+**Three typical AI examples:**
+- “From solo founders to large teams, everyone can benefit from clearer positioning.”
+- “From freelancers to agencies, everyone can use better case studies.”
+- “From small newsletters to big media brands, everyone can tell sharper stories.”
+**How to spot it:** Look for endpoint groups joined by ‘from’ and ‘to,’ followed by ‘everyone,’ ‘anyone,’ or a universal benefit. Compare the needs of both endpoints. Falsify the flag when the same action truly applies to every named group and the text proves that shared requirement.
+**The ugly version:** From first-time freelancers to multinational enterprises, everyone can use this one simple morning routine to unlock sustainable growth.
+**Exception:** Use a broad range only when the recommendation rests on a requirement shared by every named group.
+**Good use:** From one-person shops to public companies, every employer filing Form 941 must use the current IRS revision for that quarter.
+---
+## 87. Whether You Love It or Hate It
+**What it is:** Polarizing setup for a widely known phenomenon.
+**Why AI may reach for it:** ‘Whether you love it or hate it’ invents two emotional camps and then declares the topic unavoidable. It supplies conflict even when the audience is indifferent or the premise is disputed.
+**Three typical AI examples:**
+- “Whether you love it or hate it, social media shapes perception.”
+- “Whether you love it or hate it, pricing sends a signal.”
+- “Whether you love it or hate it, constraints help you focus.”
+**How to spot it:** Search for ‘love it or hate it,’ ‘like it or not,’ or paired emotional extremes before an inevitability claim. Ask whether those are the real positions. Falsify the flag when the piece reports two documented constituencies whose reactions matter to the decision.
+**The ugly version:** Whether you love it or hate it, the future has arrived, and every serious leader must embrace daily video or risk becoming invisible.
+---
+## 88. In the Context of X
+**What it is:** Academic-sounding narrowing phrase.
+**Why AI may reach for it:** ‘In the context of’ gives a sentence academic framing without necessarily narrowing anything. The model can paste it before a broad claim and make the claim sound scoped.
+**Three typical AI examples:**
+- “In the context of early-stage startups, brand is often under-valued.”
+- “In the context of B2B SaaS, churn is a silent killer.”
+- “In the context of newsletters, subject lines carry disproportionate weight.”
+**How to spot it:** Find ‘in the context of’ and test whether removing it changes the population, conditions, or meaning. Falsify the flag when the phrase establishes a boundary that is essential to interpreting the claim.
+**The ugly version:** In the context of the contemporary business environment, communication is important in the context of teams, customers, and growth.
+**Exception:** Keep the phrase when it defines the conditions under which a term, result, or rule has a different meaning.
+**Good use:** In the context of this trial, ‘recovery’ means no fever for 48 hours without medication.
+---
+## 89. In Many Ways
+**What it is:** Vague hedge to soften a strong claim.
+**Why AI may reach for it:** ‘In many ways’ softens a sweeping analogy without identifying which ways count. It lets the model make a broad equivalence while retaining an escape hatch.
+**Three typical AI examples:**
+- “In many ways, positioning is just disciplined exclusion.”
+- “In many ways, your onboarding is your real product.”
+- “In many ways, your brand is just patterns of behavior over time.”
+**How to spot it:** Search for ‘in many ways,’ ‘in some sense,’ or ‘in a way’ before a definition or analogy. List the actual dimensions of similarity. Falsify the flag when those dimensions are named immediately and the differences are also bounded.
+**The ugly version:** In many ways, a company is a living organism, a family, a machine, and a conversation all at the same time.
+---
+## 90. On Top of That
+**What it is:** Layering transition that stacks arguments.
+**Why AI may reach for it:** ‘On top of that’ treats the next point as cumulative evidence without showing that it is independent, relevant, or stronger. It encourages the model to keep stacking reasons after the argument is complete.
+**Three typical AI examples:**
+- “On top of that, inconsistent messaging erodes trust.”
+- “On top of that, your team needs a shared language.”
+- “On top of that, your metrics should reflect your strategy.”
+**How to spot it:** Mark repeated ‘on top of that,’ ‘plus,’ or ‘additionally’ openings. Draw the dependency between each claim and the conclusion. Falsify the flag when the added fact is genuinely cumulative and changes the decision rather than repeating an earlier reason.
+**The ugly version:** The tool saves time. On top of that, it improves efficiency. On top of that, it streamlines productivity. On top of that, it helps teams do more with less.
+---
+## 91. Over-Reliance on Moreover / Furthermore / In Addition
+**What it is:** Serial use of formal transitions to start sentences.
+**Why AI may reach for it:** Serial ‘moreover,’ ‘furthermore,’ and ‘in addition’ openings act as glue between independently generated sentences. They impose an essay-like progression even when the points repeat or lack a logical order.
+**Three typical AI examples:**
+- “Moreover, this approach scales with your team.”
+- “Furthermore, it reduces decision fatigue.”
+- “In addition, it clarifies who you should ignore.”
+**How to spot it:** Count paragraph-opening ‘moreover,’ ‘furthermore,’ and ‘in addition.’ Remove them and label the real relation: cause, contrast, example, or simple continuation. Falsify the flag when each transition accurately identifies a distinct additive claim and the frequency fits the genre.
+**The ugly version:** Moreover, the platform is intuitive. Furthermore, it is easy to use. In addition, users will find it simple. Moreover, this accessibility facilitates seamless adoption.
+---
+## 92. Generic Buzzword Triples
+**What it is:** Strings of buzzwords like “innovative, scalable, impactful.”
+**Why AI may reach for it:** A triple of positive buzzwords gives the model rhythm and broad approval without forcing any adjective to be observable. Three terms can simulate a complete value proposition.
+**Three typical AI examples:**
+- “Build an innovative, scalable, impactful brand.”
+- “Craft a flexible, data-driven, customer-centric strategy.”
+- “Design a simple, sustainable, repeatable system.”
+**How to spot it:** Look for three comma-separated adjectives before a broad noun, especially ‘innovative,’ ‘scalable,’ ‘impactful,’ ‘agile,’ or ‘customer-centric.’ Ask for a test for each word. Falsify the flag when every adjective maps to a separate, demonstrated property.
+**The ugly version:** Our innovative, scalable, customer-centric solution delivers agile, impactful, future-ready outcomes for modern, dynamic, purpose-driven organizations.
+---
+## 93. Overly Friendly Closing Invite
+**What it is:** Polite, generic closing that invites further questions.
+**Why AI may reach for it:** A generic offer to help is a safe conversational exit. The model can sound warm without identifying the next decision, missing input, or kind of help that would matter.
+**Three typical AI examples:**
+- “Let me know if you need any more help with this.”
+- “Feel free to ask if you’d like examples.”
+- “If you have follow-up questions, I’m here to help.”
+**How to spot it:** Look for closers such as ‘let me know if you need anything,’ ‘feel free to ask,’ or ‘I’m here to help.’ Ask whether the invitation names a useful next action. Falsify the flag when an ongoing support exchange genuinely benefits from an open channel and the writer states what can happen next.
+**The ugly version:** I hope this helps! Please feel free to reach out with absolutely any questions, thoughts, concerns, ideas, feedback, or anything else whatsoever—I’m always here and happy to help!
+**Exception:** Use a friendly invitation in an active service relationship when it names the next kind of assistance available.
+**Good use:** If the import still fails, reply with the job ID and I’ll trace that run.
+---
+## 94. Placeholder Brackets
+**What it is:** Leaving bracketed placeholders like \[your brand\] or \[insert metric\].
+**Why AI may reach for it:** Bracketed placeholders survive when the model imitates a template but does not resolve its variables. The draft looks finished at a glance while critical names, numbers, or claims remain unset.
+**Three typical AI examples:**
+- “Send a weekly update to \[your list\] with one clear promise.”
+- “Aim for a reply rate of at least \[target %\].”
+- “Make sure \[your brand name\] shows up consistently across channels.”
+**How to spot it:** Search literally for square brackets, braces, angle-bracket tokens, ‘TBD,’ ‘TK,’ and ‘insert.’ Check whether each token is declared as a variable. Falsify the flag when the document is clearly labeled as a reusable template and every placeholder has an instruction or schema.
+**The ugly version:** Hi \[FIRST NAME\], our \[ADJECTIVE\] platform helped \[CUSTOMER\] achieve \[IMPRESSIVE METRIC\], and we would love to do the same for \[YOUR COMPANY\] by \[DATE\].
+**Exception:** Placeholders belong in explicitly labeled templates when each variable is named consistently and accompanied by completion guidance.
+**Good use:** Template: ‘The test ran from \[START_DATE: YYYY-MM-DD\] through \[END_DATE: YYYY-MM-DD\] and included \[SAMPLE_SIZE: integer\] participants.’
+---
+## 95. Everything-in-Threes Cadence
+**What it is:** Repeating triple patterns across the entire piece (three sections, three bullets, three sub-bullets).
+**Why AI may reach for it:** Three-part groupings are easy for a model to predict, balance, and close. Repeating the cadence across headings, bullets, and clauses makes arbitrary sets feel designed.
+**Three typical AI examples:**
+- “Three pillars, three tactics, three examples.”
+- “Past, present, future.”
+- “Before, during, after.”
+**How to spot it:** Count triads at every level: three sections, three bullets, three adjectives, three short sentences. Try regrouping by meaning. Falsify the flag when the subject has exactly three established components or the triad is a deliberate rhetorical beat used sparingly.
+**The ugly version:** Plan with clarity, build with confidence, launch with courage. Three phases. Three principles. Three paths to a simpler, stronger, smarter future.
+**Exception:** Use a triad when the material genuinely has three components or when one deliberate three-beat cadence serves the genre.
+**Good use:** The fire triangle has three required elements: heat, fuel, and oxygen.
+---
+## 96. Perfectly Even Sentence Rhythm
+**What it is:** Medium-length sentences with similar structure and cadence throughout.
+**Why AI may reach for it:** Uniform sentence length and syntax reduce the model’s planning burden. The resulting prose stays smooth because every sentence carries the same weight, whether the ideas deserve it or not.
+**Three typical AI examples:**
+- “Your brand exists in the minds of your customers.”
+- “Your story shapes how they interpret your actions.”
+- “Your consistency decides whether they trust you.”
+**How to spot it:** Read the paragraph aloud and mark repeated subject-verb-object shapes, similar word counts, and identical pauses. Combine or split sentences according to importance. Falsify the flag when parallel rhythm is deliberate and reinforces genuinely parallel content.
+**The ugly version:** Your strategy defines the direction. Your process creates the momentum. Your discipline produces the outcome. Your consistency sustains the advantage.
+**Exception:** Even rhythm can serve a speech, poem, instruction, or parallel comparison when the ideas are truly equal and the cadence is intentional.
+**Good use:** We came to listen. We stayed to learn. We left to act.
+---
+## 97. Overuse of Bullet Lists
+**What it is:** Turning any idea into a bulleted or numbered list.
+**Why AI may reach for it:** Bullets give the model a reliable container for fragments that may not have an order or shared category. The visual structure can disguise repetition and spare the model from building an argument.
+**Three typical AI examples:**
+- “You need three things: a clear promise, a defined audience, a simple offer.”
+- “There are four reasons this fails: misfit, mis-timing, mis-pricing, mis-messaging.”
+- “Here are five levers you can pull.”
+**How to spot it:** Check whether every bullet answers the same grammatical question and has equal status. Convert the list to prose or a sequence and compare clarity. Falsify the flag when bullets improve scanning for genuinely parallel items, or numbers preserve a required order.
+**The ugly version:** Why communication matters:
+- Communication builds trust.
+- Communication creates clarity.
+- Communication improves alignment.
+- Communication helps people communicate better.
+**Exception:** Use bullets for parallel items readers need to scan and numbered lists for steps whose order matters.
+**Good use:** Bring three items to the appointment:
+- Photo ID
+- Signed consent form
+- Current medication list
+---
+## 98. Perfect Grammar, No Edge
+**What it is:** Immaculate grammar with no slang, fragments, or intentional breaks.
+**Why AI may reach for it:** The model defaults to standard grammar and neutral register because both are broadly acceptable. Without chosen diction, contractions, fragments, or emphasis, every sentence can sound equally polished and emotionally uncommitted.
+**Three typical AI examples:**
+- “This approach is highly effective for organizations of all sizes.”
+- “Such strategies can significantly improve customer engagement.”
+- “This method offers a reliable path to sustainable growth.”
+**How to spot it:** Look beyond correctness: mark uniform formality, complete sentences, generic verbs, and absence of field-specific or personal diction. Compare with the author’s normal voice. Falsify the flag when the genre requires controlled, impersonal language or the restraint improves safety and precision.
+**The ugly version:** The organization remains committed to pursuing meaningful opportunities that may support positive outcomes for relevant stakeholders over an appropriate period of time.
+**Exception:** Controlled grammar and neutral tone are appropriate in safety instructions, contracts, policies, and other genres where personality could obscure meaning.
+**Good use:** Disconnect the device from mains power before removing the rear panel.
+---
+## 99. Promotional Travel-Guide Tone
+**What it is:** Slightly promotional, brochure-like language even for neutral topics.
+**Why AI may reach for it:** Brochure verbs such as ‘discover,’ ‘experience,’ and ‘explore’ let the model turn neutral information into an invitation. The subject acquires a glow even when the reader asked for facts.
+**Three typical AI examples:**
+- “Discover a powerful way to connect with your audience.”
+- “Experience the difference a clear brand story makes.”
+- “Explore the possibilities of a more focused strategy.”
+**How to spot it:** Search for invitation verbs, sensory adjectives, and promises of a rewarding experience in neutral or analytical copy. Replace them with the concrete action. Falsify the flag when the document is actually promotional travel or hospitality copy and the described experience is specific and true.
+**The ugly version:** Discover the vibrant world of quarterly tax filing, where every form opens the door to a seamless journey through compliance.
+**Exception:** A promotional travel guide may use inviting language when it describes specific, verifiable features of the place.
+**Good use:** Walk the 2.4-kilometre cliff path at sunrise, when the eastern lookout is shaded and the lighthouse is open.
+---
+## 100. AI Vocabulary Drift
+**What it is:** High density of AI-favored words like “realm,” “leverage,” “pivotal,” “robust,” “landscape,” “underscoring.”
+**Why AI may reach for it:** A model can drift toward high-probability prestige words such as ‘realm,’ ‘pivotal,’ ‘robust,’ ‘landscape,’ and ‘underscore.’ Density matters: the words reinforce one another until generic model register replaces the subject’s vocabulary.
+**Three typical AI examples:**
+- “In the realm of modern marketing, trust is pivotal.”
+- “This robust framework helps you leverage your existing audience.”
+- “These trends are reshaping the landscape and underscoring the need for clarity.”
+**How to spot it:** Count favored terms per paragraph, including ‘delve,’ ‘leverage,’ ‘pivotal,’ ‘robust,’ ‘realm,’ ‘landscape,’ and ‘underscores.’ Substitute literal nouns and verbs, then compare information loss. Falsify the flag when each term has a precise domain meaning and the writer uses it normally elsewhere.
+**The ugly version:** Within the ever-evolving realm of innovation, this robust framework leverages pivotal insights to navigate a nuanced landscape, underscoring the transformative potential of a holistic ecosystem.
+**Exception:** Retain an individual term when it is the accepted precise word in the relevant discipline; density and generic substitution are the warning signs.
+**Good use:** The controller remained robust under packet loss: all 50 runs converged with up to 8% dropped messages.
+---
+# Patterns 101–120
+## 101. No Fluff Claim
+**What it is:** The writer explicitly promises “no fluff” or “no nonsense,” while the text remains padded.
+**Why AI may reach for it:** Promising ‘no fluff’ pre-emptively claims discipline instead of demonstrating it. The phrase lets the model frame ordinary advice as unusually direct while adding another line of setup.
+**Three typical AI examples:**
+- “No fluff, just the exact steps to improve your conversions.”
+- “Here’s the no-nonsense breakdown of brand strategy.”
+- “This guide skips the fluff and gets straight to what works.”
+**How to spot it:** Search for ‘no fluff,’ ‘no nonsense,’ ‘straight to the point,’ or ‘only what works.’ Remove the promise and measure whether the next paragraph starts with evidence or action. Falsify the flag when ‘fluff’ is explicitly defined as an excluded content type and the deliverable follows that boundary.
+**The ugly version:** No fluff, no filler, no nonsense—just a comprehensive deep dive into the essential fundamentals you absolutely need to know before getting started.
+---
+## 102. Shouting Into the Void
+**What it is:** The “posting into the void” metaphor used to dramatize low engagement.
+**Why AI may reach for it:** The void metaphor dramatizes low distribution or response without diagnosing reach, audience fit, timing, or message quality. It converts an analytics problem into loneliness.
+**Three typical AI examples:**
+- “Tired of feeling like you’re shouting into the void?”
+- “Your posts don’t have to disappear into the void.”
+- “If your content feels like a whisper in the void, read this.”
+**How to spot it:** Look for ‘shouting,’ ‘speaking,’ ‘posting,’ or ‘whispering into the void.’ Ask which observable failure the void represents. Falsify the flag when the text is deliberately literary and the emotional isolation, rather than performance data, is the actual subject.
+**The ugly version:** Every morning she hurled another carefully crafted post into the hungry digital void, where silence swallowed her expertise without leaving so much as a like.
+---
+## 103. Curious What Others Think
+**What it is:** Ending with a performative curiosity question.
+**Why AI may reach for it:** ‘Curious what others think’ simulates openness while demanding almost nothing from the writer. The broad question can be attached to any post to solicit engagement rather than information.
+**Three typical AI examples:**
+- “Curious what others think—have you tried this?”
+- “Curious what others think: is niching down worth it?”
+- “Curious what others think about daily publishing?”
+**How to spot it:** Find closers beginning ‘curious what,’ ‘thoughts?,’ or ‘what do you think?’ Check whether the question names a choice, experience, or evidence the replies could resolve. Falsify the flag when the writer is genuinely collecting bounded input and explains how it will be used.
+**The ugly version:** That is my complete argument, backed by no data and open to no real revision. Curious what others think—agree?
+**Exception:** Ask for input when the question is specific, the audience can answer it, and the response will inform a stated decision.
+**Good use:** If you used either checkout, which field caused you to stop? We will remove the most-cited field in Friday’s test.
+---
+## 104. And Honestly?
+**What it is:** Faux-confessional aside used to signal vulnerability.
+**Why AI may reach for it:** ‘And honestly?’ creates a confessional beat without requiring a real disclosure. It signals candor, then often delivers a safe opinion or another generic claim.
+**Three typical AI examples:**
+- “And honestly? Most people never get past the basics.”
+- “And honestly? Your offer is doing most of the work.”
+- “And honestly? You’re not as stuck as you think.”
+**How to spot it:** Search for sentence-fragment asides such as ‘and honestly?,’ ‘truthfully?,’ or ‘if I’m honest.’ Compare the statement after the cue with what came before. Falsify the flag when the writer reveals a concrete fact, conflict, or change of mind they had reason to withhold.
+**The ugly version:** And honestly? I was today years old when I realized that caring deeply, working hard, and believing in yourself can actually make a difference.
+**Exception:** A candid cue can work in personal speech or memoir when it introduces a specific admission that changes how the preceding account is understood.
+**Good use:** And honestly? I opposed the delay in Monday’s meeting, then changed my mind after reading the two unresolved safety reports.
+---
+## 105. Here’s the Kicker
+**What it is:** Dramatic reveal phrase as beat before a twist.
+**Why AI may reach for it:** ‘Here’s the kicker’ inserts a dramatic beat before a fact regardless of whether it reverses the argument. The model gets suspense without constructing a genuine twist.
+**Three typical AI examples:**
+- “Here’s the kicker: most of your traffic never returns.”
+- “Here’s the kicker—nobody reads your About page first.”
+- “Here’s the kicker: the best customers rarely negotiate.”
+**How to spot it:** Look for ‘here’s the kicker,’ ‘the twist,’ or a colon after a reveal label. Remove the label and test whether the fact still changes the conclusion. Falsify the flag when the reveal genuinely overturns the reader’s reasonable expectation and the tone fits the genre.
+**The ugly version:** We spent six months, twelve meetings, and the entire budget rebuilding the dashboard. Here’s the kicker: the old one also had charts.
+---
+## 106. The Part Most People Miss
+**What it is:** Claim to reveal a “hidden” component everyone else overlooks.
+**Why AI may reach for it:** ‘The part most people miss’ grants the model insider status and manufactures a negligent majority. It can elevate a familiar point without showing who missed it or why it matters.
+**Three typical AI examples:**
+- “Here’s the part most people miss: retention is marketing.”
+- “The part most people miss is how onboarding shapes trust.”
+- “The part most people miss: your brand lives in screenshots.”
+**How to spot it:** Search for ‘most people miss,’ ‘often overlooked,’ or ‘what everyone forgets.’ Ask for the comparison group and evidence of omission. Falsify the flag when a review, survey, or audit documents the specific omission and the passage cites it.
+**The ugly version:** The part most people miss about success is the overlooked secret nobody talks about: you have to keep going even when it is hard.
+**Exception:** Use the framing only when a defined review shows that a material component was repeatedly omitted.
+**Good use:** The part 17 of 20 migration plans missed was rollback ownership; the audit found a rollback command but no named operator.
+---
+## 107. You’re Not Imagining It
+**What it is:** Validation phrase that confirms the reader’s perception.
+**Why AI may reach for it:** ‘You’re not imagining it’ validates an assumed perception before confirming the reader has it. The model creates rapport by declaring a trend real without data.
+**Three typical AI examples:**
+- “You’re not imagining it—organic reach is shrinking.”
+- “You’re not imagining it; everyone sounds the same.”
+- “You’re not imagining it, attention really is getting more expensive.”
+**How to spot it:** Look for ‘you’re not imagining it,’ ‘it’s not just you,’ or ‘yes, X really is happening.’ Identify the perception and supporting measure. Falsify the flag when the audience has explicitly reported the experience and current data confirms it.
+**The ugly version:** You’re not imagining it: everything is harder, attention is disappearing, algorithms are against you, and the entire internet has become impossibly crowded.
+**Exception:** Use validation when the audience has reported a specific experience and evidence confirms the change.
+**Good use:** You’re not imagining the slower exports: median completion time rose from 42 seconds to 96 seconds after Tuesday’s release.
+---
+## 108. The Best Part? X
+**What it is:** Short question followed by one-sentence “best part” payoff.
+**Why AI may reach for it:** The fragment ‘The best part?’ creates a forced payoff and labels one benefit as superior without criteria. It gives the model a punchy mini-reveal.
+**Three typical AI examples:**
+- “The best part? You can start with what you already have.”
+- “The best part? You don’t need a large audience.”
+- “The best part? It compounds quietly in the background.”
+**How to spot it:** Search for ‘the best part?’ followed by a short answer. Ask best for whom and by what measure. Falsify the flag when the passage has already stated the decision criteria and this benefit ranks first under them.
+**The ugly version:** The best part? This effortless system saves time, cuts costs, delights customers, empowers teams, and practically runs itself.
+**Exception:** Use the label when a defined audience and stated criterion make one benefit demonstrably the most valuable.
+**Good use:** For the field team, the best part is offline access: inspectors can finish the form in tunnels with no signal.
+---
+## 109. The Kicker? X
+**What it is:** Variation of the kicker pattern with question form.
+**Why AI may reach for it:** ‘The kicker?’ is a compressed reveal template. The question mark supplies drama, while the following sentence may be only another benefit or observation.
+**Three typical AI examples:**
+- “The kicker? Your best ideas are buried in old threads.”
+- “The kicker? Your case studies are doing the selling for you.”
+- “The kicker? No one’s reading your long posts on mobile.”
+**How to spot it:** Find a standalone ‘the kicker?’ or equivalent fragment before a payoff. Test whether the payoff reverses an established expectation. Falsify the flag when it delivers a real reversal in a voice where the theatrical beat is intentional.
+**The ugly version:** The kicker? The revolutionary secret to becoming more productive was, astonishingly, making a list of things to do.
+---
+## 110. But Here’s the Truth
+**What it is:** Hot-take beat that claims to finally reveal honesty.
+**Why AI may reach for it:** ‘But here’s the truth’ labels the next claim as uniquely honest. The model gains authority through the frame instead of evidence or accountable firsthand knowledge.
+**Three typical AI examples:**
+- “But here’s the truth: most ‘strategies’ are just tactics in disguise.”
+- “But here’s the truth—your content is forgettable.”
+- “But here’s the truth: nobody trusts a brand that never takes a stand.”
+**How to spot it:** Search for ‘here’s the truth,’ ‘the truth is,’ or ‘let’s be honest’ after a contrast. Remove the frame and demand support for the remaining claim. Falsify the flag when the sentence introduces a documented correction to a specific false statement.
+**The ugly version:** But here’s the truth: every strategy fails unless you believe in it, commit to it, and show up as the most authentic version of yourself.
+---
+## 111. What Nobody’s Saying
+**What it is:** Manufactured contrarianism about a mainstream point.
+**Why AI may reach for it:** ‘What nobody’s saying’ creates contrarian novelty by erasing existing discussion. The model can repackage a common criticism as suppressed insight.
+**Three typical AI examples:**
+- “What nobody’s saying about virality is how rarely it converts.”
+- “What nobody’s saying about branding is how boring it usually is.”
+- “What nobody’s saying about funnels is how fragile they are.”
+**How to spot it:** Search for ‘nobody is saying,’ ‘no one talks about,’ or ‘the conversation no one is having.’ Check the first page of credible discussion or sources. Falsify the flag only when a defined corpus or meeting record truly lacks the point.
+**The ugly version:** What nobody’s saying about meetings is that some of them are unnecessary—a forbidden truth the business world may not be ready to hear.
+---
+## 112. Fear Not
+**What it is:** Reassuring imperative in formal tone.
+**Why AI may reach for it:** ‘Fear not’ lets the model assume anxiety and pivot into reassurance in two words. Its mock-formal tone can trivialize the actual difficulty.
+**Three typical AI examples:**
+- “Fear not—there’s a simple way to fix this.”
+- “Fear not, you don’t need fancy tools to start.”
+- “Fear not, you’re not too late to build a brand.”
+**How to spot it:** Look for ‘fear not,’ ‘do not worry,’ or ‘rest assured’ before a generic solution. Ask whether the audience expressed fear and whether the next step addresses it. Falsify the flag when the archaic tone is deliberate characterization or genre-appropriate humor.
+**The ugly version:** Fear not, weary entrepreneur, for the labyrinth of quarterly reporting can be conquered with three simple pillars and a positive mindset.
+---
+## 113. Little Did I/We Know
+**What it is:** Story hook that retroactively claims a twist.
+**Why AI may reach for it:** ‘Little did I know’ retrofits foreshadowing onto a personal story. A model can create a twist arc even when it has no lived ignorance or later discovery.
+**Three typical AI examples:**
+- “Little did we know, that campaign would change everything.”
+- “Little did I know, that tweet would land my first client.”
+- “Little did they know, the real asset was the audience.”
+**How to spot it:** Search for ‘little did I know,’ ‘we had no idea,’ or retrospective foreknowledge cues. Verify the narrator could truthfully know the earlier state and later outcome. Falsify the flag when a real narrator documents what they believed then and what evidence changed it.
+**The ugly version:** Little did I know, the ordinary Tuesday email I almost did not send would transform my business, my identity, and the future of work itself.
+**Exception:** Use it in truthful first-person narrative when the earlier ignorance and later discovery are both concrete.
+**Good use:** Little did I know that the ‘test’ server contained live records; I learned that at 14:20 when a customer replied to the test message.
+---
+## 114. Master the Art of X
+**What it is:** Grandiose promise to “master the art” of a mundane skill.
+**Why AI may reach for it:** ‘Master the art of’ enlarges a bounded skill into a prestigious lifelong craft. It promises command while avoiding a measurable level of competence.
+**Three typical AI examples:**
+- “Master the art of writing subject lines people actually open.”
+- “Master the art of turning feedback into revenue.”
+- “Master the art of building trust at scale.”
+**How to spot it:** Find ‘master the art,’ ‘mastery,’ or ‘become a master’ attached to routine tasks. Replace ‘master’ with the actual performance target. Falsify the flag when the subject is conventionally treated as an art and the text defines a credible standard of mastery.
+**The ugly version:** Master the art of clicking Send and transform every ordinary email into an unforgettable expression of strategic brilliance.
+---
+## 115. Game-Changer Label
+**What it is:** Describing everyday tools or tactics as a “game-changer.”
+**Why AI may reach for it:** ‘Game-changer’ substitutes a verdict for the rule, constraint, or result that changed. The model can inflate an ordinary improvement into a categorical shift.
+**Three typical AI examples:**
+- “This simple survey was a game-changer for our retention.”
+- “Email is still a game-changer for B2B sales.”
+- “Customer interviews were the real game-changer for our positioning.”
+**How to spot it:** Search for ‘game-changer,’ ‘changes everything,’ or ‘rewrites the rules.’ Ask which rule changed and what behavior became possible. Falsify the flag when the change alters a binding constraint and the passage quantifies the consequence.
+**The ugly version:** Adding a dark-mode toggle was an absolute game-changer that redefined productivity, transformed collaboration, and changed how the team thought about software forever.
+**Exception:** Use the label when an intervention removes a binding constraint or changes the governing rules, and show the before-and-after result.
+**Good use:** Same-day PCR was a game-changer for this ward: isolation decisions fell from a 36-hour wait to four hours, freeing 11 beds each week.
+---
+## 116. Revolutionize the Way
+**What it is:** Overblown claim to “revolutionize the way” X is done.
+**Why AI may reach for it:** ‘Revolutionize the way’ claims system-wide replacement without naming the old method or adoption. It gives the model maximal novelty from a routine feature.
+**Three typical AI examples:**
+- “Revolutionize the way you launch new products.”
+- “Revolutionize the way your team shares knowledge.”
+- “Revolutionize the way you think about churn.”
+**How to spot it:** Look for ‘revolutionize,’ ‘reinvent,’ or ‘fundamentally change the way.’ Identify the prior system, adoption breadth, and irreversible difference. Falsify the flag when evidence shows a field-wide change in practice rather than a product-level improvement.
+**The ugly version:** This color-coded spreadsheet will revolutionize the way humanity organizes tasks, collaborates across borders, and imagines the future of work.
+**Exception:** Reserve the claim for a demonstrated, broad change in established practice with evidence of adoption and displaced methods.
+**Good use:** Movable type revolutionized European book production: printers could reuse letters, produce editions faster, and replace hand-copying for mass circulation.
+---
+## 117. Unlock/Unleash Potential
+**What it is:** “Unlock” or “unleash the potential of” generic nouns.
+**Why AI may reach for it:** ‘Unlock’ and ‘unleash’ imply valuable capacity is already trapped inside a broad noun. The model can promise upside without naming the constraint, intervention, or recoverable amount.
+**Three typical AI examples:**
+- “Unlock the potential of your existing audience.”
+- “Unleash the potential of your customer data.”
+- “Unlock the potential of your long-form content.”
+**How to spot it:** Search for ‘unlock,’ ‘unleash,’ and ‘untapped potential.’ Ask what capacity exists, what blocks it, and how much becomes usable. Falsify the flag when the passage answers all three with evidence.
+**The ugly version:** Unlock the limitless potential of your data and unleash a future where every hidden insight becomes a transformative engine of growth.
+**Exception:** Use the metaphor when a known constraint blocks measurable existing capacity and the intervention removes that constraint.
+**Good use:** Adding a second loading dock unlocked 38 hours of weekly machine capacity that had been lost while trucks queued at the single bay.
+---
+## 118. Significant Milestone
+**What it is:** Vague milestone framing with no concrete detail.
+**Why AI may reach for it:** ‘Significant milestone’ adds importance to an event without stating the threshold, plan, or consequence. The model gets celebratory weight from two abstract words.
+**Three typical AI examples:**
+- “This marks a significant milestone in our growth journey.”
+- “Hitting 10k subscribers was a significant milestone for the brand.”
+- “The rebrand represented a significant milestone for our team.”
+**How to spot it:** Find ‘significant,’ ‘major,’ or ‘important milestone.’ Ask whether the threshold was defined in advance and what changes after crossing it. Falsify the flag when the milestone belongs to a published plan or has a concrete operational consequence.
+**The ugly version:** Publishing our seventh weekly update marks a significant milestone in our ongoing journey toward meaningful, sustainable, long-term communication excellence.
+**Exception:** Use the phrase for a predefined threshold that changes status, capability, or the next phase of work.
+**Good use:** Passing 10,000 verified samples is a significant milestone because it triggers the preregistered external-validation phase.
+---
+## 119. A Testament To
+**What it is:** Formal praise phrase often used instead of concrete proof.
+**Why AI may reach for it:** ‘A testament to’ turns an outcome into praise without ruling out other causes. The model can attribute success to virtue while skipping the causal chain.
+**Three typical AI examples:**
+- “The response rate is a testament to your audience’s trust.”
+- “Their loyalty is a testament to consistent delivery.”
+- “The results are a testament to the power of focus.”
+**How to spot it:** Search for ‘a testament to,’ ‘proof of,’ or ‘speaks to’ followed by a virtue such as dedication or trust. List alternative explanations. Falsify the flag when the genre is ceremonial and the sentence is clearly tribute rather than causal analysis.
+**The ugly version:** The single positive comment is a powerful testament to our unwavering commitment, exceptional vision, and profound impact on the community.
+**Exception:** Use it as explicit ceremonial praise when no causal or evidentiary claim is being smuggled into the sentence.
+**Good use:** This scholarship is a testament to Dr. Rao’s thirty years of volunteer teaching; tonight we are honoring that service, not measuring its effects.
+---
+## 120. Beacon / Lighthouse Metaphor
+**What it is:** Using “beacon” or similar as an overblown metaphor for clarity.
+**Why AI may reach for it:** Beacon and lighthouse imagery gives an abstract idea moral clarity and direction. The model can evoke guidance without identifying who is navigating, toward what, or by which signal.
+**Three typical AI examples:**
+- “Your brand should be a beacon for the right people.”
+- “Clear positioning acts as a beacon in a noisy market.”
+- “Values become a lighthouse when decisions get hard.”
+**How to spot it:** Look for ‘beacon,’ ‘lighthouse,’ ‘guiding light,’ or beams cutting through noise or darkness. Translate each element literally. Falsify the flag when the metaphor is sustained, internally consistent, and adds a precise relationship.
+**The ugly version:** Our values are a radiant lighthouse, a steadfast beacon illuminating the turbulent seas of uncertainty and guiding every stakeholder safely toward the shores of shared success.
+**Exception:** Use the image sparingly when a sustained metaphor maps source, signal, audience, and direction without mixing frames.
+**Good use:** The daily error budget is our lighthouse: when it turns red, teams stop launching and steer capacity toward reliability.
+---
+# Patterns 121–140
+## 121. Tapestry / Symphony / Tides
+**What it is:** Poetic metaphor cluster for complexity or harmony.
+**Why AI may reach for it:** Tapestries, symphonies, and tides provide ready-made beauty for complexity, coordination, or change. The model can swap among them without explaining the actual relationships.
+**Three typical AI examples:**
+- “Your strategy is a tapestry of small decisions.”
+- “Your funnel is a symphony of tiny interactions.”
+- “The tides of attention shift faster than your content.”
+**How to spot it:** Search for woven threads, orchestras, harmony, tides, waves, or currents around abstract systems. Check whether each part of the image maps consistently. Falsify the flag when the prose is deliberately literary and sustains one coherent metaphor.
+**The ugly version:** The tapestry of innovation becomes a symphony of collaboration as the tides of transformation weave every stakeholder into a harmonious wave of progress.
+**Exception:** A literary or ceremonial passage may use one sustained metaphor when its imagery is coherent and chosen for effect.
+**Good use:** In the quartet, the cello held the floor while the violin answered; the negotiation followed the same score, one voice yielding space before the other entered.
+---
+## 122. Journey as a Noun
+**What it is:** Treating every process as a “journey” with emotional weight.
+**Why AI may reach for it:** Calling every process a ‘journey’ gives it emotion, stages, and implied growth without specifying events. The noun is especially easy to attach to customers, creators, brands, and transformation.
+**Three typical AI examples:**
+- “Your brand-building journey won’t be linear.”
+- “Welcome to the next stage of your creator journey.”
+- “The customer journey doesn’t stop at checkout.”
+**How to spot it:** Find ‘journey’ after customer, user, learning, healing, brand, or transformation. Replace it with the actual process and stages. Falsify the flag when ‘customer journey’ is a defined service-design artifact with mapped touchpoints and evidence.
+**The ugly version:** Welcome to your transformative invoicing journey, where every payment milestone brings you closer to becoming the empowered business owner you were meant to be.
+**Exception:** Use ‘customer journey’ as a defined service-design term when the passage names the actor, stages, touchpoints, and evidence.
+**Good use:** The renewal journey has four observed touchpoints: the 30-day email, admin review, procurement approval, and signature.
+---
+## 123. Robust, Comprehensive, Holistic
+**What it is:** Triple-adjective bloat stacked before a noun.
+**Why AI may reach for it:** ‘Robust, comprehensive, holistic’ piles three assurances onto a noun because none is specific enough alone. The model covers resilience, scope, and systems thinking without proving any of them.
+**Three typical AI examples:**
+- “You need a robust, comprehensive, holistic strategy.”
+- “We built a robust, scalable, intuitive platform.”
+- “Invest in a comprehensive, long-term, sustainable plan.”
+**How to spot it:** Look for stacked adjectives such as ‘robust,’ ‘comprehensive,’ ‘holistic,’ ‘scalable,’ and ‘sustainable.’ Demand a separate test for each. Falsify the flag when the document defines and verifies each property independently.
+**The ugly version:** Our robust, comprehensive, holistic framework provides a scalable, sustainable, end-to-end solution for every dimension of organizational excellence.
+---
+## 124. Innovative, Cutting-Edge, State-of-the-Art
+**What it is:** Tech marketing adjective cluster.
+**Why AI may reach for it:** ‘Innovative,’ ‘cutting-edge,’ and ‘state-of-the-art’ claim novelty or technical leadership without a comparison set or date. The model can sound current while naming no advance.
+**Three typical AI examples:**
+- “An innovative, cutting-edge solution for modern teams.”
+- “A state-of-the-art platform for creators.”
+- “Cutting-edge tools for data-driven marketers.”
+**How to spot it:** Search for novelty superlatives and ask: compared with which products, on what date, and by what benchmark? Falsify the flag when ‘state of the art’ refers to a documented benchmark leader or a formal prior-art standard.
+**The ugly version:** Our innovative, cutting-edge, state-of-the-art platform brings tomorrow’s revolutionary technology to forward-thinking teams today.
+**Exception:** Use the term when a dated, named benchmark or formal review establishes the comparison.
+**Good use:** As of the March 2026 benchmark, Model A is state of the art on Dataset Q at 91.4%, 1.8 points above the previous published result.
+---
+## 125. Remarkably / Incredibly / Highly + Adjective
+**What it is:** Intensifier + adjective stack that feels generic.
+**Why AI may reach for it:** Intensifier-plus-adjective pairs let the model raise enthusiasm without changing the proposition. ‘Remarkably effective’ and ‘highly efficient’ often replace the missing measurement.
+**Three typical AI examples:**
+- “A remarkably effective way to improve retention.”
+- “Incredibly powerful positioning in a crowded market.”
+- “A highly efficient system for capturing feedback.”
+**How to spot it:** Circle ‘remarkably,’ ‘incredibly,’ ‘highly,’ ‘extremely,’ and ‘exceptionally,’ then remove them. Ask what number should carry the emphasis. Falsify the flag when the intensifier is tied to an explicit comparison or statistical magnitude.
+**The ugly version:** This incredibly powerful and remarkably effective method produces highly impressive results with exceptionally minimal effort.
+**Exception:** Keep an intensifier when a stated comparison defines the magnitude and the adjective accurately summarizes it.
+**Good use:** The treatment was highly effective in this trial: 94% cleared the infection versus 51% in the control group.
+---
+## 126. Wealth of / Treasure Trove
+**What it is:** Metaphors for lots of information or data.
+**Why AI may reach for it:** ‘A wealth of’ and ‘treasure trove’ turn an unspecified pile of information into valuable abundance. The model avoids saying how much exists, whether it is usable, or what it contains.
+**Three typical AI examples:**
+- “A wealth of insights hidden in your churn data.”
+- “Your inbox is a treasure trove of customer language.”
+- “You’re sitting on a wealth of unused testimonials.”
+**How to spot it:** Search for riches metaphors around data, insights, content, or experience. Ask for count, quality, and retrieval method. Falsify the flag when the prose is deliberately playful and the next sentence inventories the material precisely.
+**The ugly version:** Your neglected inbox is a glittering treasure trove overflowing with a wealth of priceless insights just waiting to unlock untold growth.
+---
+## 127. Dive Deeper / Deep Dive
+**What it is:** Invitation to go into detail, often repeated.
+**Why AI may reach for it:** ‘Deep dive’ promises depth as a format label. The model can lengthen an answer, repeat context, or add headings without increasing evidence, mechanism, or resolution.
+**Three typical AI examples:**
+- “Let’s dive deeper into how this actually works.”
+- “This deep dive explores the psychology behind pricing.”
+- “For a deeper dive, look at your last 100 signups.”
+**How to spot it:** Search for ‘deep dive,’ ‘dive deeper,’ and ‘in-depth.’ Test the promised depth: does the section add primary evidence, causal detail, edge cases, or a worked analysis? Falsify the flag when the linked or following material demonstrably provides that added depth.
+**The ugly version:** This deep dive dives deeper into the depths of engagement, exploring every layer of why audiences engage and how deeper engagement can drive engagement.
+**Exception:** Use the label for material that is substantially more detailed than the surrounding summary and specify what extra depth it contains.
+**Good use:** For the deep dive, see Appendix B: 14 failure traces, the retry-state diagram, and a line-by-line analysis of the race condition.
+---
+## 128. Shed Light On
+**What it is:** Mildly dramatic verb for “explain” or “clarify.”
+**Why AI may reach for it:** ‘Shed light on’ supplies a discovery metaphor for ordinary explanation or correlation. It can make incomplete evidence sound clarifying without stating what uncertainty was reduced.
+**Three typical AI examples:**
+- “These metrics shed light on why users churn.”
+- “Customer calls shed light on hidden objections.”
+- “This framework sheds light on your real constraints.”
+**How to spot it:** Look for studies, metrics, or interviews that ‘shed light on’ a topic. Replace the phrase with ‘shows,’ ‘suggests,’ or the exact result. Falsify the flag when the evidence genuinely narrows a named uncertainty and the passage states how.
+**The ugly version:** These powerful insights shed much-needed light on the hidden forces illuminating the path toward a clearer understanding of customer behavior.
+**Exception:** Use the metaphor sparingly when evidence narrows a clearly stated uncertainty and the result follows immediately.
+**Good use:** The interviews shed light on the cancellation spike: 18 of 23 customers believed the annual price shown was a monthly price.
+---
+## 129. The Power of X
+**What it is:** Abstract “power of” framing instead of concrete benefit.
+**Why AI may reach for it:** ‘The power of X’ turns a topic into a benefit claim before identifying its mechanism or size. The model gets an energetic title from an abstract noun.
+**Three typical AI examples:**
+- “The power of constraints in creative work.”
+- “The power of repetition in brand-building.”
+- “The power of simple promises in crowded markets.”
+**How to spot it:** Search headings and hooks for ‘the power of.’ Ask what X changes, through which mechanism, and by how much. Falsify the flag when the section answers those questions with evidence rather than treating power as self-evident.
+**The ugly version:** Discover the extraordinary power of simplicity to unlock clarity, inspire action, transform outcomes, and reshape what is possible.
+**Exception:** Use the frame when the passage immediately demonstrates a specific mechanism and measured effect.
+**Good use:** The power of batching came from setup time: processing 20 samples together cut calibration from 20 runs to one and saved 95 minutes.
+---
+## 130. At the Heart of X
+**What it is:** Essence metaphor centered on “heart.”
+**Why AI may reach for it:** ‘At the heart of’ declares one factor central through metaphor rather than causal analysis. The model can reduce a multi-cause system to a pleasing essence.
+**Three typical AI examples:**
+- “At the heart of every strong brand is a clear promise.”
+- “At the heart of retention is expectation management.”
+- “At the heart of good strategy is brutal focus.”
+**How to spot it:** Find ‘at the heart,’ ‘at the center,’ or ‘the core of’ before a broad claim. Ask whether the factor is necessary, sufficient, or simply important. Falsify the flag when the system literally has a central component or evidence identifies the factor as the main causal bottleneck.
+**The ugly version:** At the heart of every thriving organization lies trust, and at the heart of trust lies communication, and at the heart of communication lies authenticity.
+---
+## 131. Crucial / Critical / Pivotal Role
+**What it is:** Emphasis on importance without specifics.
+**Why AI may reach for it:** Calling a role ‘crucial,’ ‘critical,’ or ‘pivotal’ marks importance without naming the failure prevented or outcome changed. The model can emphasize almost any supporting factor.
+**Three typical AI examples:**
+- “Positioning plays a crucial role in your growth.”
+- “Onboarding has a pivotal role in retention.”
+- “Trust is critical in high-ticket sales.”
+**How to spot it:** Search for importance adjectives near ‘role,’ ‘part,’ or ‘factor.’ Delete the adjective and state the consequence of absence. Falsify the flag when the passage names that consequence and evidence shows the factor is necessary.
+**The ugly version:** Clear communication plays an absolutely crucial, deeply critical, and undeniably pivotal role in driving meaningful success across every area.
+**Exception:** Use ‘critical’ when failure or absence produces a specified, material consequence.
+**Good use:** The backup pump is critical: if the primary fails during dialysis, flow stops within 12 seconds without it.
+---
+## 132. Playbook Language
+**What it is:** Calling simple lists or examples a “playbook.”
+**Why AI may reach for it:** Calling advice a ‘playbook’ implies reusable moves, triggers, and decision rules. The model often applies the label to a short list that says what to do but not when, by whom, or under which conditions.
+**Three typical AI examples:**
+- “Here’s a simple playbook for launching a new offer.”
+- “Use this playbook to improve your onboarding.”
+- “A positioning playbook for crowded categories.”
+**How to spot it:** Look for ‘playbook’ in titles and promises. Check for roles, triggers, ordered actions, branching conditions, and stop criteria. Falsify the flag when the document contains those operational elements and has been tested in the stated situation.
+**The ugly version:** The ultimate growth playbook: know your audience, create value, stay consistent, measure results, and never stop improving.
+**Exception:** Use ‘playbook’ for a reusable operational guide that names triggers, owners, actions, branches, and exit conditions.
+**Good use:** Incident playbook: when checkout errors exceed 2% for five minutes, the on-call engineer disables the new gateway, verifies recovery, and opens a severity-one review.
+---
+## 133. Blueprint Language
+**What it is:** Using “blueprint” to make a plan sound precise.
+**Why AI may reach for it:** ‘Blueprint’ borrows the precision of a construction drawing. The model can make broad strategic advice sound implementation-ready without dimensions, dependencies, or specifications.
+**Three typical AI examples:**
+- “A blueprint for scaling your content engine.”
+- “Use this blueprint to redesign your funnel.”
+- “A simple blueprint for building authority.”
+**How to spot it:** Search for ‘blueprint’ attached to growth, authority, content, or transformation. Ask whether another person could build from it without making major design choices. Falsify the flag when it specifies components, interfaces, constraints, and measurements at implementation depth.
+**The ugly version:** Use this proven blueprint to build an unforgettable brand: be clear, be consistent, be authentic, and keep showing up.
+**Exception:** Use ‘blueprint’ for a detailed specification that defines components, relationships, dimensions, and constraints.
+**Good use:** The network blueprint names every subnet, gateway, firewall rule, failover path, and address range required for installation.
+---
+## 134. Roadmap Language
+**What it is:** Calling any future plan a “roadmap.”
+**Why AI may reach for it:** ‘Roadmap’ makes any future-oriented list sound sequenced and governed. The model often omits dates, dependencies, owners, decision gates, and the reason priorities may change.
+**Three typical AI examples:**
+- “Here’s a roadmap to go from 0 to 10k subscribers.”
+- “Build a roadmap for your next 12 months of content.”
+- “A roadmap for turning followers into customers.”
+**How to spot it:** Find ‘roadmap’ and check for time horizons, outcomes, dependencies, owners, and review gates. Falsify the flag when those elements are present and the document distinguishes commitments from options.
+**The ugly version:** Our roadmap to category leadership is simple: create awareness, build trust, drive growth, expand globally, and become the brand everyone loves.
+**Exception:** Use ‘roadmap’ for a time-ordered plan with outcomes, dependencies, owners, and explicit review points.
+**Good use:** Q3 roadmap: Priya owns SSO by August 15; audit logging follows because it depends on the new identity events; the September 1 review decides whether SCIM enters Q4.
+---
+## 135. Step-by-Step Roadmap Hybrid
+**What it is:** Combining “step-by-step” with “roadmap” or “blueprint.”
+**Why AI may reach for it:** Combining ‘step-by-step’ with ‘roadmap’ or ‘blueprint’ stacks two promises of order and precision. The model can oversell a generic sequence as both complete instructions and strategic direction.
+**Three typical AI examples:**
+- “A step-by-step roadmap to your first 100 customers.”
+- “Follow this step-by-step blueprint to launch.”
+- “A step-by-step roadmap for repositioning your brand.”
+**How to spot it:** Search for ‘step-by-step roadmap,’ ‘step-by-step blueprint,’ or similar doubled containers. Check whether each step has inputs, action, output, and dependency. Falsify the flag when the task is truly linear and the document supplies executable detail for every step.
+**The ugly version:** Follow this step-by-step roadmap blueprint: dream bigger, define your vision, take inspired action, build momentum, and unlock unstoppable success.
+**Exception:** Use the hybrid only for a genuinely linear implementation plan whose steps include inputs, actions, outputs, and dependencies.
+**Good use:** The step-by-step migration roadmap lists the schema backup, checksum, write freeze, copy command, verification query, cutover, and rollback trigger in execution order.
+---
+## 136. In This Article / Guide / Post
+**What it is:** Meta opener that explains what the piece will do.
+**Why AI may reach for it:** ‘In this article’ narrates the document instead of beginning its work. The model uses the meta opener to forecast familiar sections and establish coherence before making a claim.
+**Three typical AI examples:**
+- “In this article, we’ll explore how to build trust.”
+- “In this guide, you’ll learn a simple framework.”
+- “In this post, we’ll walk through the process.”
+**How to spot it:** Look for ‘in this article,’ ‘in this guide,’ or ‘in this post’ followed by ‘we will explore,’ ‘you will learn,’ or a topic list. Remove it and test whether scope becomes unclear. Falsify the flag when a long or technical document needs a precise scope statement, prerequisites, or navigation aid.
+**The ugly version:** In this comprehensive article, we will explore everything you need to know about communication, why it matters, how it works, and the key steps you can take today.
+**Exception:** Use a meta introduction when it gives readers concrete scope, prerequisites, exclusions, or navigation they need before proceeding.
+**Good use:** This guide covers rotating an existing API key without downtime. It assumes two active deployment slots and does not cover initial key creation.
+---
+## 137. This Piece Explores
+**What it is:** Slightly more formal variation of the meta opener.
+**Why AI may reach for it:** ‘This piece explores’ is a more formal self-description that lets the model announce intellectual work instead of stating its question, method, or finding.
+**Three typical AI examples:**
+- “This piece explores why most funnels leak.”
+- “This piece explores the link between story and sales.”
+- “This piece explores how to retain customers longer.”
+**How to spot it:** Search for ‘this piece explores,’ ‘this paper examines,’ or ‘the present article considers.’ Ask whether the sentence names a research question, corpus, and method. Falsify the flag when the genre requires an abstract-like scope sentence and those specifics are present.
+**The ugly version:** This piece explores the multifaceted interplay between innovation and growth, examining the nuanced dynamics that shape success in an evolving world.
+**Exception:** Formal scope language is appropriate in an abstract when it identifies the exact question, material, and method.
+**Good use:** This paper examines 1,204 eviction filings from 2022–2025 to test whether notice length predicts default judgments.
+---
+## 138. Key Insights / Key Takeaways
+**What it is:** Labeling points as “key insights” without ranking.
+**Why AI may reach for it:** ‘Key insights’ and ‘key takeaways’ declare priority without showing the ranking rule. The model can label every summary point as key and make a routine recap feel curated.
+**Three typical AI examples:**
+- “Here are the key insights from these interviews.”
+- “Three key insights from our last launch.”
+- “Key takeaways from 6 months of testing.”
+**How to spot it:** Find ‘key’ before insights, findings, lessons, or takeaways. Ask which decision each item affects and why excluded points rank lower. Falsify the flag when the list is selective, evidence-backed, and tied to a defined reader decision.
+**The ugly version:** Key insight one: customers matter. Key insight two: quality matters. Key insight three: consistent quality for customers matters most.
+**Exception:** Use the label for a selective summary whose items are ranked by a stated decision or audience need.
+**Good use:** Key takeaways for Friday’s launch decision: the crash rate exceeds the 1% stop threshold, rollback takes four minutes, and no fix has passed load testing.
+---
+## 139. From X to Y: Range Examples
+**What it is:** Using extreme range pairs for emphasis (tiny to huge, new to experienced).
+**Why AI may reach for it:** A ‘from X to Y’ range implies breadth by choosing distant endpoints. The model can claim universal coverage while skipping the populations or stages between them.
+**Three typical AI examples:**
+- “From tiny startups to global brands, everyone competes for attention.”
+- “From first-time buyers to loyal fans, expectations are rising.”
+- “From early-stage founders to veteran operators, storytelling matters.”
+**How to spot it:** Look for ‘from’ and ‘to’ joining extremes in audience, size, time, or process. List the intermediate cases and test whether the claim holds for each. Falsify the flag when the endpoints bound a real, continuous range represented in the evidence.
+**The ugly version:** From curious beginners taking their first tentative step to visionary global leaders reshaping entire industries, this one timeless framework works for absolutely everyone.
+**Exception:** Use a range when the endpoints are real bounds and the evidence or process covers the intermediate values.
+**Good use:** The sensor is calibrated from −20°C to 60°C in 5°C increments, with error below 0.3°C at every tested point.
+---
+## 140. Bustling / Vibrant / Dynamic
+**What it is:** Overly vivid but generic adjectives for markets and communities.
+**Why AI may reach for it:** ‘Bustling,’ ‘vibrant,’ and ‘dynamic’ add ready-made motion and positivity to markets or communities. The model can create atmosphere without naming who is present or what is changing.
+**Three typical AI examples:**
+- “In today’s bustling creator economy…”
+- “A vibrant community of builders and makers.”
+- “A dynamic, fast-moving landscape of tools.”
+**How to spot it:** Circle vivid adjectives around cities, communities, markets, and industries. Ask for observable movement, diversity, or rate of change. Falsify the flag when concrete sensory or measured details earn the adjective.
+**The ugly version:** Step into a bustling, vibrant, dynamic ecosystem where passionate innovators connect, collaborate, and create limitless possibilities every single day.
+**Exception:** Use the adjective when nearby concrete observations show the activity or change it summarizes.
+**Good use:** The market was bustling by 6 a.m.: 83 stalls were open, delivery carts blocked both lanes, and buyers queued three deep at the fish counters.
+---
+# Patterns 141–160
+## 141. Landscape / Ecosystem / Space
+**What it is:** Treating industries as “landscapes” or “spaces.”
+**Why AI may reach for it:** ‘Landscape,’ ‘ecosystem,’ and ‘space’ let the model refer to a field without naming its actors or relationships. The nouns create breadth and complexity by default.
+**Three typical AI examples:**
+- “In the crowded landscape of SaaS tools…”
+- “In the creator economy space…”
+- “The ecosystem of marketing tools is exploding.”
+**How to spot it:** Find abstract uses of ‘landscape,’ ‘ecosystem,’ and ‘space.’ Replace them with the actual market, institutions, firms, tools, or rules. Falsify the flag when ‘ecosystem’ names documented interdependence or the word is literal.
+**The ugly version:** Across today’s rapidly shifting technology landscape, a complex ecosystem of players is transforming the AI space in unprecedented ways.
+**Exception:** Use ‘ecosystem’ when the passage identifies interdependent actors and exchanges, or use any of the terms in their literal technical sense.
+**Good use:** The payments ecosystem here includes the merchant, gateway, acquiring bank, card network, and issuer; a failed authorization can originate at any of those five links.
+---
+## 142. Realm / Sphere
+**What it is:** Slightly mystical nouns for domains or fields.
+**Why AI may reach for it:** ‘Realm’ and ‘sphere’ elevate an ordinary domain with spatial or mystical distance. The model can vary ‘field’ without becoming more specific.
+**Three typical AI examples:**
+- “In the realm of personal branding…”
+- “In the sphere of customer success…”
+- “In the realm of newsletter publishing…”
+**How to spot it:** Search for ‘in the realm of’ and ‘within the sphere of’ before abstract topics. Substitute the actual discipline, jurisdiction, or activity. Falsify the flag when the term is literal or has a defined technical meaning.
+**The ugly version:** Within the ever-expanding realm of digital possibility, brands enter a new sphere where imagination and innovation know no boundaries.
+**Exception:** Keep the words in literal or established technical uses, not as ornamental substitutes for ‘field.’
+**Good use:** Every point on the sphere is 10 centimetres from its centre.
+---
+## 143. Navigate / Navigate Through
+**What it is:** Navigation verbs for dealing with complexity.
+**Why AI may reach for it:** ‘Navigate’ casts any choice or difficulty as travel through terrain. The model gets motion and competence without listing the branches, hazards, or destination.
+**Three typical AI examples:**
+- “Navigate the chaos of social algorithms.”
+- “Navigate through a crowded category.”
+- “Navigate complex buying committees.”
+**How to spot it:** Search for ‘navigate,’ ‘navigate through,’ ‘chart a course,’ or ‘find your way’ around abstract problems. Replace the metaphor with the decisions required. Falsify the flag when the passage presents a real branching process or literal navigation.
+**The ugly version:** Navigate the turbulent waters of modern leadership with a trusted roadmap that guides you through every twist and turn toward success.
+**Exception:** Use the verb literally or when the text maps a genuine branching decision process with hazards and destinations.
+**Good use:** The wizard helps applicants navigate three branches: resident, cross-border employee, or non-resident contractor, each with different tax forms.
+---
+## 144. Embark On
+**What it is:** Journey verb used to start projects.
+**Why AI may reach for it:** ‘Embark on’ turns the start of routine work into the departure point of an adventure. It adds ceremony before the model has named the first action.
+**Three typical AI examples:**
+- “Embark on your brand-building journey.”
+- “Embark on a new phase of experimentation.”
+- “Embark on a path toward clearer positioning.”
+**How to spot it:** Look for ‘embark on’ followed by journey, path, transformation, initiative, or phase. Replace it with ‘start’ and compare meaning. Falsify the flag when the subject is a literal voyage or the elevated register is intentionally ceremonial.
+**The ugly version:** Embark on a transformative journey of spreadsheet optimization and set sail toward a bold new horizon of administrative excellence.
+**Exception:** Use ‘embark’ for a literal voyage or a deliberately ceremonial departure where the register fits.
+**Good use:** The research vessel embarks on its 47-day Antarctic survey from Hobart on 3 November.
+---
+## 145. Take Your X to New Heights
+**What it is:** Upward-movement cliché for improvement.
+**Why AI may reach for it:** ‘Take X to new heights’ promises upward improvement while avoiding the metric, current level, and target. The vertical metaphor supplies excitement but no destination.
+**Three typical AI examples:**
+- “Take your content to new heights.”
+- “Take your onboarding to new heights.”
+- “Take your storytelling to new heights.”
+**How to spot it:** Search for ‘new heights,’ ‘next level,’ ‘soar,’ or ‘reach new peaks.’ Ask which measure rises and to what target. Falsify the flag when the height is literal or a sustained metaphor with a stated metric.
+**The ugly version:** Take your weekly status meetings to breathtaking new heights and watch team alignment soar beyond every imaginable limit.
+---
+## 146. Elevate Your X
+**What it is:** Another upward-movement verb heavily overused by AI.
+**Why AI may reach for it:** ‘Elevate’ replaces a specific improvement verb with an aspirational upward motion. The model can attach it to brand, experience, content, or conversation without committing to a result.
+**Three typical AI examples:**
+- “Elevate your brand with consistent visuals.”
+- “Elevate your copy with real customer language.”
+- “Elevate your onboarding with one simple tweak.”
+**How to spot it:** Find abstract objects being ‘elevated.’ Substitute the actual action—shorten, clarify, raise, reduce, or redesign—and require a measure. Falsify the flag when physical elevation is literal or the metaphor is deliberately sustained.
+**The ugly version:** Elevate your brand, elevate your message, and elevate every customer interaction into a premium moment of unforgettable excellence.
+---
+## 147. Enhance / Boost / Improve
+**What it is:** Soft verbs with no clear metric.
+**Why AI may reach for it:** Generic improvement verbs let the model claim positive movement without choosing a variable. ‘Enhance,’ ‘boost,’ and ‘improve’ can hide whether the goal is speed, accuracy, volume, quality, or satisfaction.
+**Three typical AI examples:**
+- “Enhance your customer experience.”
+- “Boost engagement with better hooks.”
+- “Improve retention with clearer expectations.”
+**How to spot it:** Circle ‘enhance,’ ‘boost,’ and ‘improve,’ then ask ‘which measure, from what baseline, by when?’ Falsify the flag when the verb has a named metric, direction, comparison period, and material mechanism.
+**The ugly version:** Enhance performance, boost engagement, and improve outcomes with a powerful solution designed to make everything work better.
+**Exception:** Use a general improvement verb when the sentence immediately names the metric, baseline, target, period, and mechanism.
+**Good use:** The revised reminder improved 30-day renewal from 61% to 68% in the May cohort by linking directly to the saved payment screen.
+---
+## 148. Supercharge
+**What it is:** Comic-book verb for “slightly improve.”
+**Why AI may reach for it:** “Supercharge” gives a small improvement the emotional scale of an engine upgrade. It lets AI promise acceleration without naming what changes, how much it changes, or which action causes the change.
+**Three typical AI examples:**
+- “Supercharge your content distribution.”
+- “Supercharge your email list growth.”
+- “Supercharge your customer research.”
+**How to spot it:** Cue: “supercharge” attached to a broad goal such as growth, productivity, engagement, or research. Ask for the changed input, metric, baseline, and expected gain. Falsification test: if removing “supercharge” loses no factual information, the verb is carrying hype rather than meaning.
+**The ugly version:** Supercharge your entire content ecosystem with one powerful calendar that amplifies every channel, accelerates every campaign, and sends your engagement into overdrive—without changing your budget, team, or strategy.
+---
+## 149. Turbocharge
+**What it is:** Variation of supercharge, equally inflated.
+**Why AI may reach for it:** “Turbocharge” borrows the drama of forced engine induction to make ordinary optimization sound sudden and extreme. AI can use it instead of explaining the mechanism, limits, and time required for improvement.
+**Three typical AI examples:**
+- “Turbocharge your experimentation velocity.”
+- “Turbocharge how quickly you learn from the market.”
+- “Turbocharge your brand awareness.”
+**How to spot it:** Cue: “turbocharge” followed by an abstract result such as awareness, learning, innovation, or velocity. Look for missing quantities and missing causal steps. Falsification test: if the sentence cannot be rewritten with a precise action and measurable result, it is promotional inflation.
+**The ugly version:** Turbocharge your experimentation velocity, turbocharge your market learning, and turbocharge your brand awareness with a single weekly meeting that transforms slow ideas into explosive growth.
+---
+## 150. X on Steroids
+**What it is:** Intensifier metaphor that exaggerates scale.
+**Why AI may reach for it:** “X on steroids” supplies instant magnitude without defining the dimension being enlarged. It is easy for AI to extend because almost any tool, process, or result can be framed as a stronger version of something familiar.
+**Three typical AI examples:**
+- “Think of this as your onboarding on steroids.”
+- “It’s like customer research on steroids.”
+- “It’s your content engine on steroids.”
+**How to spot it:** Cue: “on steroids” used as the whole explanation of scale or capability. Ask: larger in users, speed, cost, automation, risk, or complexity? Falsification test: if the writer can state the dimension and amount of change, the comparison is unnecessary; if they cannot, it was never informative.
+**The ugly version:** Our new onboarding is customer success on steroids: more messages, more pop-ups, more checklists, more reminders, and more automation hitting every user before they have finished creating an account.
+---
+## 151. X at Its Finest
+**What it is:** Claiming an example represents the pinnacle.
+**Why AI may reach for it:** “At its finest” lets AI pronounce a winner without establishing a comparison set or criteria. The phrase sounds evaluative while avoiding the work of showing what makes the example unusually good.
+**Three typical AI examples:**
+- “This is brand storytelling at its finest.”
+- “This is onboarding design at its finest.”
+- “This is constraint-based creativity at its finest.”
+**How to spot it:** Cue: “X at its finest” after praise, a screenshot, or an anecdote. Look for absent standards, alternatives, and evidence. Falsification test: if the writer cannot name the criteria on which the example outperforms comparable work, the superlative is unsupported.
+**The ugly version:** This is onboarding at its finest: seven tooltips, four confirmation emails, a mandatory product tour, and a celebratory animation before the user has completed a single useful task.
+**Exception:** It can work as clearly subjective criticism or praise when the reviewer names the feature being judged and the comparison set is understood.
+**Good use:** For deadpan office comedy, this is Armando Iannucci at his finest: the scene turns one missing folder into a five-person panic without breaking character.
+---
+## 152. Championing / Advocating For
+**What it is:** Formal verbs for “supporting” or “pushing.”
+**Why AI may reach for it:** “Championing” and “advocating for” can turn passive approval into the appearance of sustained action. AI reaches for them because they confer moral purpose without requiring names, policies, votes, budgets, or other proof of advocacy.
+**Three typical AI examples:**
+- “Brands championing customer privacy stand out.”
+- “He’s been championing simple funnels for years.”
+- “They advocate for radical transparency.”
+**How to spot it:** Cue: a person or company is said to be “championing” a value, community, or cause. Check for an observable act: testimony, funding, policy work, representation, or a public position. Falsification test: if documented action and responsibility are present, the verb may be exact; if only supportive language exists, it is image-building.
+**The ugly version:** We are championing privacy, advocating for transparency, and standing up for user choice through a values page that explains none of our data retention, advertising, or deletion practices.
+**Exception:** Use these verbs for documented, sustained advocacy or formal representation—not for a favorable opinion or a marketing statement.
+**Good use:** The coalition advocated for the accessibility amendment for eighteen months, submitted draft language, and testified at all three committee hearings.
+---
+## 153. Foster / Cultivate
+**What it is:** Gardening metaphors for building relationships or culture.
+**Why AI may reach for it:** “Foster” and “cultivate” make relationships, trust, and culture sound like natural growth that follows from good intentions. AI uses the gardening frame to skip the repeated behaviors, incentives, and time that actually produce the result.
+**Three typical AI examples:**
+- “Foster a sense of belonging with your content.”
+- “Cultivate long-term loyalty with consistent delivery.”
+- “Foster trust through honest messaging.”
+**How to spot it:** Cue: “foster” or “cultivate” followed by trust, belonging, loyalty, innovation, or culture. Ask what repeated action creates the condition and how progress is observed. Falsification test: if the sentence names the practice, participants, and evidence of gradual development, the verb is doing real work.
+**The ugly version:** Foster authentic belonging, cultivate unbreakable trust, and grow a vibrant culture by sending a monthly values newsletter from leadership to employees who cannot reply.
+**Exception:** The verbs are useful when they describe gradual development caused by named, repeated practices.
+**Good use:** Weekly peer reviews cultivated a shared editing standard: by the third month, factual corrections per draft had fallen from six to two.
+---
+## 154. Bolster / Underpin / Underscore
+**What it is:** Academic verbs that inflate basic points.
+**Why AI may reach for it:** These verbs imply different evidence relationships, but AI often treats them as interchangeable upgrades for “show” or “support.” The formal tone can make a weak connection sound logically established.
+**Three typical AI examples:**
+- “These case studies bolster your claims.”
+- “Trust underpins every repeat purchase.”
+- “The data underscores how critical onboarding is.”
+**How to spot it:** Cue: “bolster,” “underpin,” or “underscore” where the subject-object relationship is vague. Test the verb literally: evidence may bolster a claim, a premise may underpin an argument, and a contrast may underscore a result. Falsification test: if a plainer verb changes the claimed relationship, the formal verb may be precise; if not, it is decoration.
+**The ugly version:** The survey underscores our strategy, bolsters our culture, and underpins the pivotal importance of innovation, although it asked twelve employees only whether they enjoyed the off-site.
+**Exception:** Use each verb when its specific logical relationship is accurate and the supporting evidence is visible.
+**Good use:** The control group’s unchanged error rate bolsters the claim that the new checklist, rather than seasonal demand, caused the reduction.
+---
+## 155. Seamless Experience
+**What it is:** UX cliché for any slightly smooth flow.
+**Why AI may reach for it:** “Seamless experience” compresses every handoff, wait, error, and recovery path into one positive adjective. AI favors it because the phrase sounds like a complete UX outcome without requiring task-level evidence.
+**Three typical AI examples:**
+- “Create a seamless experience from first click to renewal.”
+- “A seamless checkout experience reduces drop-off.”
+- “Design a seamless transition from trial to paid.”
+**How to spot it:** Cue: “seamless” applied to a flow spanning screens, teams, devices, or services. Inspect authentication, data re-entry, loading, failure recovery, and handoffs. Falsification test: if observed users complete the named flow without repeated information, unexplained waits, or manual repair—and the claim identifies that flow—the word may be justified.
+**The ugly version:** Enjoy a seamless account migration: export three CSV files, email them to support, wait five business days, reset every password, and manually rebuild any dashboard that fails to appear.
+**Exception:** Use “seamless” only for a named, tested flow whose handoffs are genuinely invisible to the user.
+**Good use:** In testing, all 24 participants moved from the free trial to paid without re-entering billing details or losing their saved work, so the upgrade handoff was seamless.
+---
+## 156. Frictionless Journey
+**What it is:** Cousin of “seamless,” using friction metaphor.
+**Why AI may reach for it:** “Frictionless journey” makes all effort sound like a design defect and hides which step is slow, confusing, or unnecessary. AI can praise a flow with the metaphor without reporting completion time, abandonment, errors, or user effort.
+**Three typical AI examples:**
+- “Reduce friction in the sign-up journey.”
+- “A frictionless journey keeps users moving.”
+- “Design for a frictionless upgrade path.”
+**How to spot it:** Cue: “frictionless” or “reduce friction” without a named task. Separate useful friction, such as confirmation before deletion, from waste, such as duplicate data entry. Falsification test: if the writer identifies the removed step and measured its effect without erasing a safety control, the friction claim is specific.
+**The ugly version:** We created a frictionless loan journey by hiding the repayment schedule, preselecting consent, and replacing the final review screen with a bright button labeled “Continue.”
+**Exception:** UX teams can use “friction” as a technical shorthand when they identify the exact user effort, preserve necessary safeguards, and measure the change.
+**Good use:** Removing the second address form cut median checkout time by 38 seconds while leaving payment confirmation intact; that eliminated duplicate-entry friction.
+---
+## 157. Pain Points Language
+**What it is:** Repeated use of “pain points” instead of specific problems.
+**Why AI may reach for it:** “Pain points” lets AI discuss customers without naming any customer’s actual delay, cost, fear, failed task, or workaround. The category label can substitute for research and make generic copy look customer-aware.
+**Three typical AI examples:**
+- “Identify your customer’s pain points.”
+- “Speak directly to their pain points in your copy.”
+- “Map your product to the biggest pain points.”
+**How to spot it:** Cue: “pain point” repeated where a concrete problem should appear. Replace it with who encounters what problem, in which situation, and with what consequence. Falsification test: if the phrase is an internal tag linked to verbatim research and specific evidence, it is useful shorthand; if it appears in customer-facing copy, it is usually hiding the problem.
+**The ugly version:** Our solution addresses your biggest pain points by identifying pain-point-driven opportunities and mapping every feature to the pain points that matter most across the customer journey.
+**Exception:** Use “pain point” as an internal research category when each item links to a concrete observation or quotation.
+**Good use:** Research tag: billing pain point. Evidence: 11 of 16 admins exported invoices to a spreadsheet because the product could not group charges by cost centre.
+---
+## 158. Low-Hanging Fruit
+**What it is:** Business cliché for easy opportunities.
+**Why AI may reach for it:** “Low-hanging fruit” declares an opportunity easy before anyone estimates access, dependencies, risk, or effort. AI uses the familiar business metaphor to make prioritization sound self-evident.
+**Three typical AI examples:**
+- “Fixing onboarding is low-hanging fruit for retention.”
+- “Your existing list is low-hanging fruit for revenue.”
+- “Reusing wins as case studies is low-hanging fruit.”
+**How to spot it:** Cue: an initiative labeled “low-hanging fruit” with no effort-impact comparison. Ask who can do it, what blocks it, how long it takes, and what result is expected. Falsification test: if effort, dependencies, risk, and expected impact are quantified against alternatives, the label can function as team shorthand.
+**The ugly version:** International expansion is the obvious low-hanging fruit: translate the homepage, switch on global payments, and start collecting revenue from 40 countries by Friday.
+**Exception:** It can be useful inside a documented prioritization exercise when “low” effort and likely impact have explicit thresholds.
+**Good use:** The broken help link is low-hanging fruit under our rubric: one owner, a ten-minute change, no dependency, and 1,400 failed clicks last month.
+---
+## 159. Quick Wins
+**What it is:** Promise of easy, immediate gains.
+**Why AI may reach for it:** “Quick wins” promises speed and payoff while leaving both undefined. AI reaches for the phrase because it creates momentum without distinguishing a visible activity from a result that matters.
+**Three typical AI examples:**
+- “Focus on quick wins to build momentum.”
+- “Here are three quick wins for your funnel.”
+- “Quick wins buy you time for deeper changes.”
+**How to spot it:** Cue: a list of “quick wins” lacking owner, deadline, cost, and success measure. Check whether the item changes an outcome or merely creates motion. Falsification test: if “quick” has a time bound and “win” has a measurable benefit, the label is legitimate.
+**The ugly version:** Three quick wins for retention: redesign the dashboard, launch a loyalty program, and rebuild onboarding before the end of the sprint.
+**Exception:** Use the label for bounded actions that can be completed quickly and produce a defined, observable benefit.
+**Good use:** Quick win: add the missing password-reset link today; support received 86 reset requests last week, and the existing route already works.
+---
+## 160. Silver Bullet Denial
+**What it is:** Claims there’s no silver bullet right before giving a pseudo-one.
+**Why AI may reach for it:** The silver-bullet denial gives AI credibility for rejecting easy answers, then allows it to smuggle in a preferred tactic as the near-magical exception. The caveat protects the recommendation from scrutiny.
+**Three typical AI examples:**
+- “There’s no silver bullet, but this framework gets close.”
+- “There’s no silver bullet, yet case studies come pretty close.”
+- “No silver bullet exists, though a clear promise solves a lot.”
+**How to spot it:** Cue: “there is no silver bullet, but…” followed by one framework, tool, habit, or channel. Compare the caution with the promise that follows. Falsification test: if the passage keeps multiple causes in view, states trade-offs, and does not elevate one tactic into a universal answer, the denial is honest.
+**The ugly version:** There is no silver bullet for growth, but our seven-step organic flywheel solves acquisition, activation, retention, referrals, and revenue for every company at every stage.
+**Exception:** The phrase can introduce a genuine multi-causal explanation when the writer does not immediately nominate a pseudo-silver bullet.
+**Good use:** There is no silver bullet for churn: the last quarter’s cancellations split across missing integrations, failed cards, and slow onboarding, so each cause needs a different response.
+---
+# Patterns 161–180
+## 161. The Harsh Reality
+**What it is:** Dramatic setup for a mildly obvious fact.
+**Why AI may reach for it:** “The harsh reality” preloads a statement with severity and positions the writer as unusually candid. AI can use the frame to turn a truism or unsupported opinion into a supposedly brave conclusion.
+**Three typical AI examples:**
+- “The harsh reality is nobody owes you attention.”
+- “The harsh reality is your competitors are more memorable.”
+- “The harsh reality is algorithms don’t care about your effort.”
+**How to spot it:** Cue: “the harsh reality is” before a claim that is neither surprising nor evidenced. Remove the preface and inspect what remains. Falsification test: if the sentence becomes ordinary or weaker without the announcement, the drama—not the fact—created its force.
+**The ugly version:** The harsh reality is that if you are not publishing twelve pieces a day, building a personal brand, mastering AI, and networking constantly, you have already chosen irrelevance.
+---
+## 162. The Ugly Truth
+**What it is:** Similar to harsh reality, more clickbaity.
+**Why AI may reach for it:** “The ugly truth” manufactures a hidden, unpleasant revelation before revealing anything. AI uses it as a ready-made click hook that can make a familiar observation feel forbidden or courageous.
+**Three typical AI examples:**
+- “The ugly truth about your churn rate.”
+- “The ugly truth about your engagement metrics.”
+- “The ugly truth about most personal brands.”
+**How to spot it:** Cue: “the ugly truth about…” in a title or reveal sentence. Ask whether the claim is both substantiated and meaningfully concealed. Falsification test: if a direct factual headline is stronger and equally clear, the “ugly truth” frame is clickbait.
+**The ugly version:** The ugly truth about your employees is that they do not crave purpose, flexibility, or respect—they crave the motivational power of another mandatory Monday meeting.
+---
+## 163. Brutal Honesty / Real Talk
+**What it is:** Announcing honesty instead of just being blunt.
+**Why AI may reach for it:** “Brutal honesty” and “real talk” announce candor so the following judgment can feel earned without evidence or accountability. AI can mimic a personal voice while taking no personal risk.
+**Three typical AI examples:**
+- “Brutal honesty: your offer is generic.”
+- “Real talk: your content is safe and forgettable.”
+- “Brutal honesty: you’re hiding behind tactics.”
+**How to spot it:** Cue: an honesty label immediately before criticism, advice, or a hot take. Ask what the speaker admits, risks, or supports with firsthand knowledge. Falsification test: if the statement records a genuine first-person admission or a needed shift in tone, the aside may be authentic; if it merely licenses bluntness, it is performance.
+**The ugly version:** Brutal honesty: your product is forgettable, your marketing is weak, your team lacks conviction, and the only courageous move left is buying my strategy package.
+**Exception:** A real speaker may use the phrase to mark a genuine admission, especially when the admission reflects badly on the speaker rather than attacking the reader.
+**Good use:** Real talk: I approved the rushed launch, ignored two warnings from support, and caused the rollback we are discussing.
+---
+## 164. You Deserve
+**What it is:** Flattering claim about what the reader “deserves.”
+**Why AI may reach for it:** “You deserve” flatters the reader and creates moral certainty without knowing their circumstances. AI can attach it to any product or aspiration, turning preference into entitlement and persuasion into validation.
+**Three typical AI examples:**
+- “You deserve a brand that reflects your work.”
+- “You deserve clients who respect your boundaries.”
+- “You deserve a funnel that doesn’t feel pushy.”
+**How to spot it:** Cue: “you deserve” followed by a purchase, lifestyle, relationship, audience, or outcome. Ask who established the entitlement and whether a legal, contractual, or ethical right exists. Falsification test: if the right is explicit and verifiable, the wording can be accurate; if the sentence leads toward a sale, it is probably flattery.
+**The ugly version:** You deserve a premium brand, effortless growth, respectful clients, a calm calendar, and the confidence that comes from our £4,000 messaging intensive.
+**Exception:** Use “deserve” for an established right, promised service level, or minimum standard—not as a bridge to a product pitch.
+**Good use:** You paid for next-day delivery and the order arrived six days late; under the guarantee, you deserve a full refund of the shipping fee.
+---
+## 165. You’re Not Wrong to Feel X
+**What it is:** Validating emotional reaction in dramatic language.
+**Why AI may reach for it:** “You’re not wrong to feel…” lets AI simulate empathy by assigning an emotion and validating it in the same breath. The move feels personal even when the model has no evidence that the reader feels that way.
+**Three typical AI examples:**
+- “You’re not wrong to feel burnt out.”
+- “You’re not wrong to feel frustrated by slow growth.”
+- “You’re not wrong to feel skeptical of the latest tactics.”
+**How to spot it:** Cue: second-person emotion labeling—“you’re not wrong to feel,” “it’s valid to feel,” or “of course you feel.” Check whether the reader stated the emotion or research established it for this audience. Falsification test: if the feeling is directly reported and the response accurately reflects its cause without diagnosing the person, validation is warranted.
+**The ugly version:** You’re not wrong to feel exhausted, overlooked, anxious, and secretly angry at your team; those feelings prove your current productivity system has failed you.
+**Exception:** Validate a feeling when the person has expressed it or when the context supplies strong, specific evidence. Do not invent an inner state.
+**Good use:** You said the three surprise scope changes left you frustrated. That reaction makes sense; the deadline stayed fixed while the work increased.
+---
+## 166. Quietly / Silently
+**What it is:** Adverbs highlighting subtle impact.
+**Why AI may reach for it:** “Quietly” and “silently” let AI make an ordinary or unmeasured effect sound hidden and consequential. The adverb supplies intrigue without showing that the change was actually hard to observe.
+**Three typical AI examples:**
+- “Quietly compounding trust over time.”
+- “Silently killing your retention.”
+- “Quietly shaping how people talk about you.”
+**How to spot it:** Cue: “quietly” or “silently” before growing, killing, reshaping, eroding, or transforming. Ask what observation would reveal the effect and why it escaped notice. Falsification test: if the process is genuinely low-visibility and the writer supplies a delayed or indirect measure, the adverb is descriptive rather than dramatic.
+**The ugly version:** A single beige button is quietly destroying your revenue, silently eroding customer trust, and invisibly reshaping how the market perceives your entire company.
+**Exception:** Use the adverbs for effects that are genuinely difficult to notice directly and are demonstrated through a specific lagging or indirect measure.
+**Good use:** Failed card retries quietly increased involuntary churn: customers saw no error, but payment logs showed 312 subscriptions ending after the third attempt.
+---
+## 167. The Silent Killer
+**What it is:** Labeling something (churn, confusion) a “silent killer.”
+**Why AI may reach for it:** “The silent killer” imports the stakes of an unnoticed lethal condition into ordinary business problems. AI uses the label to create fear and urgency without measuring prevalence, harm, or causation.
+**Three typical AI examples:**
+- “Churn is the silent killer of SaaS growth.”
+- “Inconsistent branding is the silent killer of trust.”
+- “Weak onboarding is the silent killer of upgrades.”
+**How to spot it:** Cue: a non-medical issue called a “silent killer.” Look for a vague noun such as confusion, inconsistency, churn, or complacency and no causal evidence. Falsification test: unless the phrase is the established literal name of a documented health risk, replace it with the specific harm and rate.
+**The ugly version:** Misaligned button padding is the silent killer of SaaS growth, draining trust, conversions, morale, and market share while your dashboards remain blissfully unaware.
+---
+## 168. Hidden Gem / Hidden Lever
+**What it is:** Suggesting underused tactic as “hidden.”
+**Why AI may reach for it:** “Hidden gem” and “hidden lever” allow AI to present familiar advice as proprietary discovery. The words create scarcity and insider status without showing that the tactic is underused or unusually effective.
+**Three typical AI examples:**
+- “Customer interviews are the hidden gem of marketing.”
+- “Positioning is the hidden lever behind growth.”
+- “Testimonials are the hidden lever in your funnel.”
+**How to spot it:** Cue: “hidden” attached to a common feature, channel, metric, or tactic. Check adoption data, prior coverage, and comparative impact. Falsification test: if the item is demonstrably overlooked by the defined audience and evidence shows unusual value, “hidden” may describe its status rather than manufacture it.
+**The ugly version:** The hidden lever behind every billion-dollar brand is a weekly customer email—the overlooked secret nobody in marketing has discovered until now.
+**Exception:** Use “hidden” when the information is genuinely difficult for the intended audience to find and the writer can show both low visibility and practical value.
+**Good use:** The accessibility menu contains a hidden keyboard shortcut: fewer than 1% of surveyed users knew it existed, yet it cuts the repeated task from six keystrokes to two.
+---
+## 169. Behind Every X Lies Y
+**What it is:** Behind-the-scenes abstraction.
+**Why AI may reach for it:** “Behind every X lies Y” gives AI a universal causal sentence with a polished reveal. It turns one possible contributor into the secret explanation for every success, failure, or visible outcome.
+**Three typical AI examples:**
+- “Behind every strong brand lies a simple promise.”
+- “Behind every great launch lies months of prep.”
+- “Behind every viral post lies a clear angle.”
+**How to spot it:** Cue: “behind every” or “behind each” followed by one cause. Test the universal quantifier by looking for one counterexample or another necessary cause. Falsification test: if a single credible counterexample exists, “every” fails and the causal claim must be narrowed.
+**The ugly version:** Behind every successful launch lies one fearless founder, one crystal-clear story, and one perfectly timed post that makes strategy, product quality, pricing, and distribution almost irrelevant.
+---
+## 170. Beneath the Surface
+**What it is:** Depth metaphor similar to “on the surface/beneath.”
+**Why AI may reach for it:** “Beneath the surface” promises a deeper diagnosis before evidence has established one. AI can convert a visible metric into a more profound-sounding explanation simply by placing an abstract cause underneath it.
+**Three typical AI examples:**
+- “Beneath the surface, it’s a trust problem, not a traffic problem.”
+- “Beneath the surface, your churn is about misaligned expectations.”
+- “Beneath the surface, your brand feels inconsistent.”
+**How to spot it:** Cue: surface/depth language followed by a confident root-cause claim. Trace the evidence from the visible symptom to the supposed underlying cause. Falsification test: if the deeper explanation is not supported by interviews, logs, experiments, or another causal source, the metaphor is posing as analysis.
+**The ugly version:** Beneath the surface of your 2% checkout drop lies a profound crisis of trust, identity, positioning, belonging, and brand purpose that only a complete rebrand can resolve.
+---
+## 171. Scratch the Surface
+**What it is:** Shallow-depth metaphor.
+**Why AI may reach for it:** “Scratch the surface” lets AI acknowledge limited coverage while implying a large, important body of material beyond the page. The promise of depth can mask the fact that the writer has not identified what remains.
+**Three typical AI examples:**
+- “Most advice only scratches the surface.”
+- “We’ve barely scratched the surface of what’s possible with your list.”
+- “These metrics just scratch the surface of customer sentiment.”
+**How to spot it:** Cue: “only scratches the surface” or “barely scratched the surface.” Ask what unexamined layers, sources, or questions remain. Falsification test: if the writer names the excluded scope and points to the next evidence, the phrase accurately marks a boundary; if not, it is a vague promise of hidden depth.
+**The ugly version:** This 300-word post barely scratches the surface of leadership, psychology, culture, incentives, communication, trust, conflict, hiring, strategy, and the future of work.
+**Exception:** Use it to mark a real scope boundary when the omitted material is named and available for further examination.
+**Good use:** This chart covers reported incidents only; it scratches the surface because it excludes near misses, contractor reports, and cases settled before investigation.
+---
+## 172. Tip of the Iceberg
+**What it is:** Classic visual metaphor for unseen depth.
+**Why AI may reach for it:** “Tip of the iceberg” gives AI an easy visible-versus-hidden model and suggests the unseen part is much larger. The metaphor often appears without evidence that a hidden population exists or dwarfs the observed one.
+**Three typical AI examples:**
+- “Your open rate is just the tip of the iceberg.”
+- “That one angry tweet is the tip of the iceberg.”
+- “The visible churn is the tip of the iceberg.”
+**How to spot it:** Cue: one observed event called “the tip of the iceberg.” Look for an estimate of the unseen total and a method for producing it. Falsification test: if sampling, reporting rates, or linked records support a much larger hidden set, the metaphor can summarize that relationship; otherwise it exaggerates.
+**The ugly version:** One negative comment is only the tip of the iceberg: thousands of silent customers are probably furious, preparing to churn, and warning everyone they know.
+**Exception:** Use the metaphor when evidence supports a substantially larger hidden set and the visible observation is genuinely part of it.
+**Good use:** The 18 confirmed cases are the tip of the iceberg: randomized testing found the defect in 7% of 4,000 devices, implying roughly 280 affected units.
+---
+## 173. Flood / Avalanche / Tsunami of X
+**What it is:** Disaster metaphors for large quantities.
+**Why AI may reach for it:** Flood, avalanche, and tsunami metaphors turn high volume into physical disaster. AI reaches for them because they supply scale, motion, and threat without requiring a count or explaining the actual consequence of volume.
+**Three typical AI examples:**
+- “A flood of content competing for attention.”
+- “An avalanche of notifications your users ignore.”
+- “A tsunami of options overwhelming your buyers.”
+**How to spot it:** Cue: a disaster noun attached to emails, content, notifications, data, choices, or demand. Ask for the rate, total, time window, capacity, and failure caused by the volume. Falsification test: if ordinary quantity words communicate the same fact, the disaster image is emotional inflation.
+**The ugly version:** A tsunami of content is crashing over your customers while an avalanche of notifications buries their attention beneath a flood of unstoppable brand noise.
+---
+## 174. Noise vs Signal
+**What it is:** Overused information-theory metaphor.
+**Why AI may reach for it:** “Noise versus signal” offers AI a clean binary for separating useful from useless information. Outside technical contexts, it often avoids defining the decision, the data-generating process, and the criterion that makes one observation informative.
+**Three typical AI examples:**
+- “Cut through the noise and get to the signal.”
+- “Your job is to separate noise from signal.”
+- “Most metrics are noise; behavior is the signal.”
+**How to spot it:** Cue: people, metrics, posts, or opinions divided into “noise” and “signal.” Ask: signal of what, for which decision, measured how? Falsification test: if signal and noise are defined within a statistical, engineering, or analytic model, the terms are technical; if they mean “things I like” and “things I ignore,” they are rhetoric.
+**The ugly version:** Ignore the noise—competitor prices, customer objections, cash flow, and product defects—and focus on the only signal that matters: believing in your vision.
+**Exception:** Use the terms when a defined measurement process distinguishes information relevant to a specific inference from random or unwanted variation.
+**Good use:** To estimate the 60 Hz signal, the filter removes higher-frequency sensor noise introduced by the motor.
+---
+## 175. North Star
+**What it is:** Guiding-star metaphor for main metric or goal.
+**Why AI may reach for it:** “North Star” turns a priority into a guiding celestial object and can hide who chose it, which trade-offs it governs, and what counter-metrics prevent harm. AI uses it to make a vague goal sound stable and strategic.
+**Three typical AI examples:**
+- “Choose a single North Star metric for your team.”
+- “Your brand promise should act as a North Star.”
+- “Retention can be your North Star for growth decisions.”
+**How to spot it:** Cue: a value, promise, or metric called the “North Star.” Ask for its formula, owner, decision use, review period, and guardrails. Falsification test: if the team has formally selected one metric that guides recurring trade-offs and has named its limits, the established product term is precise.
+**The ugly version:** Customer love is our North Star, with engagement as our compass, innovation as our map, and growth as the horizon—so every team can interpret success however it prefers.
+**Exception:** “North Star metric” is legitimate product terminology when one defined measure guides trade-offs and is balanced by guardrail metrics.
+**Good use:** Our North Star metric is weekly documents successfully shared with a collaborator; we review it with spam reports and failed-share rate as guardrails.
+---
+## 176. Low Barrier / High Leverage
+**What it is:** Framing actions by low effort vs high impact.
+**Why AI may reach for it:** “Low barrier” and “high leverage” compress effort and impact into attractive labels without supplying the comparison. AI can recommend an action as efficient while ignoring prerequisites, probability, delayed costs, and who does the work.
+**Three typical AI examples:**
+- “High-leverage actions with a low barrier to entry.”
+- “Cold emails are low-cost, high-leverage.”
+- “Testimonials are high-leverage proof assets.”
+**How to spot it:** Cue: “low barrier,” “low effort,” or “high leverage” with no matrix or numbers. Ask for cost, skill, dependency, expected effect, confidence, and timeframe. Falsification test: if the action is compared against alternatives on explicit effort and impact criteria, the labels summarize analysis rather than replace it.
+**The ugly version:** Enterprise sales is a low-barrier, high-leverage growth channel: send a few personalized emails and one conversation can transform the company overnight.
+**Exception:** Use the terms in a real effort-versus-impact comparison with defined thresholds and uncertainty.
+**Good use:** Adding the existing demo video to the confirmation email is low effort—one template edit—and potentially high leverage because 41% of new users open that email.
+---
+## 177. Double-Edged Sword
+**What it is:** Cliché for trade-offs.
+**Why AI may reach for it:** “Double-edged sword” tells the reader a trade-off exists without naming either causal edge. AI uses the familiar object to sound balanced while skipping who benefits, who is harmed, and under which conditions.
+**Three typical AI examples:**
+- “Virality is a double-edged sword.”
+- “Discounting is a double-edged sword.”
+- “Automation can be a double-edged sword.”
+**How to spot it:** Cue: a tool, policy, or outcome called a “double-edged sword,” followed by vague advantages and disadvantages. Demand one mechanism that produces the benefit and one that produces the cost. Falsification test: if both effects are specific, evidenced, and arise from the same feature, the metaphor accurately compresses a real trade-off.
+**The ugly version:** Automation is a double-edged sword: it saves time but changes everything, creates opportunities but raises concerns, and helps people while also affecting them.
+**Exception:** Use it when the same mechanism creates a concrete benefit and a concrete harm that matter to the decision.
+**Good use:** Auto-approval is a double-edged sword: it cuts median wait time from two days to four minutes, but the same lack of review increased fraudulent payouts by 18%.
+---
+## 178. Blessing and a Curse
+**What it is:** Another cliché for trade-offs.
+**Why AI may reach for it:** “A blessing and a curse” supplies a ready-made emotional balance without explaining the trade-off. AI can place any success, resource, or visibility inside the frame and appear nuanced without analyzing conditions.
+**Three typical AI examples:**
+- “Attention is both a blessing and a curse.”
+- “Going viral can be a blessing and a curse.”
+- “A large audience is a blessing and a curse.”
+**How to spot it:** Cue: one condition described as both blessing and curse, especially when neither side is concrete. Ask which people receive each effect and what mechanism connects them. Falsification test: if the speaker is describing a real personal experience and gives specific, linked benefits and costs, the colloquial phrase may fit.
+**The ugly version:** Going viral was a blessing and a curse: it was amazing but overwhelming, exciting but scary, good but bad, and ultimately a lot to process.
+**Exception:** The phrase can work in personal or informal writing when the writer names the specific benefit and cost rather than using it as a substitute for them.
+**Good use:** The grant was a blessing and a curse: it funded the clinic for a year, but its reporting rules took our only nurse away from patients every Friday.
+---
+## 179. Skeleton / Framework / Scaffolding
+**What it is:** Building metaphors for conceptual structures.
+**Why AI may reach for it:** Skeleton, framework, and scaffolding can make a loose collection of ideas sound engineered. AI uses building language to imply stable parts and relationships even when the document contains only headings or suggestions.
+**Three typical AI examples:**
+- “Use this framework as scaffolding, not scripture.”
+- “This skeleton gives your onboarding structure.”
+- “A simple framework beats scattered ideas.”
+**How to spot it:** Cue: a list called a framework, skeleton, or scaffolding. Identify its elements, relationships, intended use, and whether any part is temporary. Falsification test: if the structure is reused to analyze cases or guide work—and provisional parts are named—the metaphor has a functional meaning.
+**The ugly version:** Our proprietary TRUST framework is the strategic scaffolding and operational skeleton for every customer decision, although it consists of five unrelated words chosen to spell TRUST.
+**Exception:** Use these terms when they distinguish an organizing structure from finished content or when the elements have stable relationships and repeated use.
+**Good use:** This outline is scaffolding: the evidence table will replace sections 2–4 once the interviews are coded.
+---
+## 180. X Is the New Y
+**What it is:** Trend-framing cliché.
+**Why AI may reach for it:** “X is the new Y” gives AI a compact trend headline by claiming replacement or equivalence. The symmetry feels insightful even when X and Y perform different functions and no change over time has been shown.
+**Three typical AI examples:**
+- “Attention is the new currency.”
+- “Trust is the new growth hack.”
+- “Retention is the new acquisition.”
+**How to spot it:** Cue: “X is the new Y” involving currencies, moats, acquisition, media, or strategy. Test whether X has actually replaced Y for a defined group, task, or period. Falsification test: if both remain important or the relation is merely metaphorical, the substitution claim fails.
+**The ugly version:** Trust is the new currency, retention is the new acquisition, community is the new moat, and attention is the new oil—so every old business concept can finally become a newer metaphor.
+---
+# Patterns 181–200
+## 181. Now More Than Ever
+**What it is:** Time-pressure phrase suggesting urgency.
+**Why AI may reach for it:** “Now more than ever” creates urgency by asserting a historical maximum without comparing the present with any earlier period. AI can make a timeless principle feel newly critical without dates or data.
+**Three typical AI examples:**
+- “Now more than ever, trust matters.”
+- “Now more than ever, clarity beats volume.”
+- “Now more than ever, differentiation is survival.”
+**How to spot it:** Cue: “now more than ever” before values such as trust, clarity, resilience, or leadership. Ask what changed, when, by how much, and compared with which prior period. Falsification test: if the writer supplies a relevant time series or a dated event that materially increased the need, the comparison may hold.
+**The ugly version:** Now more than ever, in a world changing faster than ever, brands must communicate more clearly than ever if they want to matter more than ever.
+**Exception:** Use the phrase only when evidence supports a present historical high or a dated change has clearly increased the requirement.
+**Good use:** Now more than ever, the reservoir needs rationing: storage is at 18%, the lowest July level in the 62-year record.
+---
+## 182. In Today’s World / Age / Era
+**What it is:** Temporal grandstanding similar to “fast-paced world.”
+**Why AI may reach for it:** “In today’s world/age/era” gives AI a universal opening and a vague reason for urgency. It avoids identifying the specific technology, law, behavior, or market change that makes the present relevant.
+**Three typical AI examples:**
+- “In today’s world, your brand lives online.”
+- “In the digital age, every touchpoint is public.”
+- “In this era of infinite content, focus is rare.”
+**How to spot it:** Cue: a sentence beginning with “in today’s world,” “in the digital age,” or “in this era.” Delete the temporal frame and see whether the claim changes. Falsification test: if a dated development changes the claim’s mechanism or scope and is named immediately, temporal framing is justified.
+**The ugly version:** In today’s digital world and fast-moving age of constant change, every modern organization must embrace the realities of this unprecedented era.
+**Exception:** Temporal framing is legitimate when the passage defines the period and names the development that distinguishes it.
+**Good use:** In the post-2024 reporting regime, companies must disclose Scope 3 emissions that were optional under the previous rule.
+---
+## 183. Increasingly + Adjective
+**What it is:** Trend intensifier that often lacks data.
+**Why AI may reach for it:** “Increasingly” turns a current state into a trend. AI uses it to imply movement without providing two time points, a rate, or even the direction’s consistency.
+**Three typical AI examples:**
+- “Attention is increasingly scarce.”
+- “Buyers are increasingly skeptical.”
+- “Audiences are increasingly distracted.”
+**How to spot it:** Cue: “increasingly” before scarce, complex, important, skeptical, digital, or difficult. Find the metric and at least two comparable periods. Falsification test: if the time series shows a sustained increase in the named measure, the adverb is factual; a single current observation cannot support it.
+**The ugly version:** Customers are increasingly skeptical, increasingly distracted, increasingly demanding, and increasingly unwilling to tolerate the increasingly complex modern marketplace.
+**Exception:** Use “increasingly” when comparable observations across time show the named measure rising.
+**Good use:** Buyers are increasingly choosing annual plans: the share rose from 21% in 2023 to 34% in 2024 and 47% in 2025.
+---
+## 184. Ever-Increasing / Constantly Growing
+**What it is:** Exponential-sounding adjectives without numbers.
+**Why AI may reach for it:** “Ever-increasing” and “constantly growing” imply uninterrupted growth, often indefinitely. AI reaches for them because exponential-sounding motion creates stakes without a baseline, rate, pause, or reversal.
+**Three typical AI examples:**
+- “An ever-increasing volume of content.”
+- “Constantly growing expectations from customers.”
+- “An ever-increasing number of tools to choose from.”
+**How to spot it:** Cue: “ever-increasing,” “constantly growing,” or “continually expanding.” Check whether the measure has observations across the whole claimed period and whether any decline breaks “constant.” Falsification test: if growth is monotonic over a stated window and the amount is reported, the wording is supportable.
+**The ugly version:** Teams face an ever-increasing, constantly growing, endlessly expanding universe of tools, demands, messages, expectations, and opportunities every single day.
+**Exception:** Use these terms only for a stated period in which the measured quantity actually rises without reversal.
+**Good use:** During the six-hour load test, queue depth was constantly growing—from 400 jobs at noon to 8,700 at 6 p.m.—because arrivals exceeded processing capacity.
+---
+## 185. The Rise of X
+**What it is:** Headline trope for trend explanation.
+**Why AI may reach for it:** “The rise of X” gives AI an instant trend narrative and headline. It can turn a few visible examples into a movement without showing adoption, prevalence, geography, or duration.
+**Three typical AI examples:**
+- “The rise of the creator-founder.”
+- “The rise of audience-first businesses.”
+- “The rise of founder-led brands.”
+**How to spot it:** Cue: “the rise of” in a title or opening. Look for a measured increase, start and end dates, denominator, and defined population. Falsification test: if the evidence shows sustained growth rather than a handful of anecdotes, “rise” is a fair summary.
+**The ugly version:** The rise of the creator-founder marks the rise of audience-first business and the rise of a new economy in which everyone with a phone becomes a category-defining company.
+**Exception:** Use “the rise of” for a documented, sustained increase in a defined phenomenon.
+**Good use:** The rise of heat-pump installations is measurable: annual UK installations increased from 55,000 in 2021 to 220,000 in 2025.
+---
+## 186. New Era of X
+**What it is:** Hyperbolic era-framing.
+**Why AI may reach for it:** “A new era” divides time into before and after without proving that the underlying rules changed. AI uses era language to make a product launch or trend sound historically decisive.
+**Three typical AI examples:**
+- “A new era of AI-assisted creativity.”
+- “A new era of audience-first brands.”
+- “A new era of permission-based marketing.”
+**How to spot it:** Cue: “a new era of” attached to a technology, brand, workplace practice, or campaign. Ask for the breakpoint and which institutions, capabilities, or constraints changed after it. Falsification test: if historians or domain evidence can define the period by durable structural changes, “era” may be warranted.
+**The ugly version:** Our redesigned settings page ushers in a new era of human-centred productivity, ending decades of confusion and beginning a bold chapter for digital work.
+**Exception:** Use era framing when a dated breakpoint produces durable, field-wide changes—not for an ordinary launch.
+**Good use:** The 1947 partition began a new era in regional migration policy: two new states, new borders, and new citizenship rules changed movement across the subcontinent.
+---
+## 187. As Never Before / Like Never Before
+**What it is:** Overblown uniqueness claim.
+**Why AI may reach for it:** “Like never before” claims unprecedented access, speed, choice, or risk without checking the historical record. AI uses the phrase to inflate novelty while leaving the comparison period undefined.
+**Three typical AI examples:**
+- “Customers have more choices than ever before.”
+- “You can reach your audience like never before.”
+- “Data is available like never before.”
+**How to spot it:** Cue: “as never before,” “like never before,” or “more than ever before.” Identify the metric, historical range, and previous maximum. Falsification test: if current data exceed every comparable prior observation in the defined record, the uniqueness claim is defensible.
+**The ugly version:** AI lets every person create, connect, compete, collaborate, and transform their future like never before in the entire history of human possibility.
+**Exception:** Use the phrase only when a defined record shows the present measure is genuinely unprecedented.
+**Good use:** During the storm, the river rose like never before in the gauge’s 94-year record, reaching 8.4 metres above the previous 7.9-metre maximum.
+---
+## 188. X Has Never Been More Important
+**What it is:** Max-importance claim for basic concepts.
+**Why AI may reach for it:** “Has never been more important” combines an unsupported historical maximum with an abstract importance claim. AI can attach it to any enduring virtue and manufacture urgency without specifying stakes or alternatives.
+**Three typical AI examples:**
+- “Retention has never been more important.”
+- “Trust has never been more important.”
+- “Differentiation has never been more important.”
+**How to spot it:** Cue: the exact superlative attached to trust, leadership, resilience, clarity, security, or differentiation. Ask how importance is measured and which prior periods were compared. Falsification test: if no valid historical importance measure exists, the claim cannot be verified and should be replaced by the current consequence.
+**The ugly version:** Trust has never been more important, clarity has never been more vital, and authentic differentiation has never been more essential than in this unprecedented moment.
+---
+## 189. Let That Sink In
+**What it is:** Dramatic pause after a metric or statement.
+**Why AI may reach for it:** “Let that sink in” instructs the reader to feel the weight of a claim instead of helping them interpret it. AI uses the pause as a dramatic beat even when the number lacks a denominator, comparison, or consequence.
+**Three typical AI examples:**
+- “Only 2% of visitors convert. Let that sink in.”
+- “Most of your content is never seen. Let that sink in.”
+- “Customers decide in seconds. Let that sink in.”
+**How to spot it:** Cue: the standalone command after a statistic or aphorism. Inspect the preceding claim for source, denominator, baseline, and practical meaning. Falsification test: if replacing the command with an explanation improves understanding, the pause was emotional direction rather than analysis.
+**The ugly version:** Only 3% of visitors clicked the purple button. Let that sink in. Three percent. A number so profound it may change everything you thought you knew about digital behaviour.
+---
+## 190. If You Think About It
+**What it is:** Conversational prompt for a simple observation.
+**Why AI may reach for it:** “If you think about it” presents a simple observation as a conclusion reached through reflection. AI uses the phrase to create conversational intimacy and intellectual momentum without adding reasoning.
+**Three typical AI examples:**
+- “If you think about it, every touchpoint is a trust test.”
+- “If you think about it, churn is delayed disappointment.”
+- “If you think about it, your brand is gossip about you.”
+**How to spot it:** Cue: “if you think about it” before a metaphor, redefinition, or truism. Remove the invitation and ask whether an actual inference remains. Falsification test: if the passage supplies intermediate reasoning that the reader must follow, state that reasoning directly; if not, the phrase is filler.
+**The ugly version:** If you think about it, your brand is a relationship, your product is a promise, your funnel is a conversation, and your revenue is really just trust wearing a number.
+---
+## 191. The Reality Check
+**What it is:** Labeling a paragraph as “reality check.”
+**Why AI may reach for it:** “Reality check” gives AI an authoritative interruption and frames the next opinion as indisputable. It can simulate blunt expertise without supplying the facts that would make the correction real.
+**Three typical AI examples:**
+- “Reality check: nobody reads your About page first.”
+- “Reality check: most people won’t remember your logo.”
+- “Reality check: your competitors are also shipping.”
+**How to spot it:** Cue: “reality check:” before criticism or a contrarian statement. Ask what earlier belief is being corrected and what evidence contradicts it. Falsification test: if the passage cannot name the mistaken forecast and the observed result, it is attitude rather than a check against reality.
+**The ugly version:** Reality check: nobody cares about your product, your story, your effort, or your vision until you stop making excuses and start posting every day.
+---
+## 192. On Paper vs In Practice
+**What it is:** Contrast between theoretical and real-world behavior.
+**Why AI may reach for it:** “On paper versus in practice” gives AI a useful contrast shape, but it can invent a gap without comparing the documented design with observed behaviour. The form sounds empirical even when both halves are assumptions.
+**Three typical AI examples:**
+- “On paper, the funnel looks clean; in practice, it’s messy.”
+- “On paper, the pricing makes sense; in practice, it confuses people.”
+- “On paper, your ICP is clear; in practice, it’s vague.”
+**How to spot it:** Cue: “on paper” paired with “in practice,” “in reality,” or “in the real world.” Locate the plan, model, or specification and the observation that diverged from it. Falsification test: if both artefacts are available and the cause of the gap is examined, the contrast is analytical rather than decorative.
+**The ugly version:** On paper, our strategy is clear; in practice, people are people, markets are messy, execution is hard, and therefore no one can reasonably ask which part of the strategy failed.
+**Exception:** Use the contrast when a documented design or prediction can be compared with observed behaviour.
+**Good use:** On paper, the retry policy allows three attempts; in practice, the proxy also retries twice, so one failed payment can produce six charges.
+---
+## 193. Worst-Case Scenario
+**What it is:** Fear-setting phrase for risk.
+**Why AI may reach for it:** “Worst-case scenario” can turn speculation into a concrete-sounding endpoint. AI may choose an implausibly mild case to reassure or an extreme case to frighten, without probability, assumptions, or mitigation.
+**Three typical AI examples:**
+- “Worst-case scenario, you learn and iterate.”
+- “Worst-case scenario, the campaign flops and you adjust.”
+- “Worst-case scenario, you discover what doesn’t work.”
+**How to spot it:** Cue: the label without a stated hazard model, time window, or probability. Ask what assumptions produce the scenario and whether a worse credible outcome exists. Falsification test: if the scenario is bounded, plausible, and tied to mitigation, it belongs in risk analysis.
+**The ugly version:** Worst-case scenario, the launch fails, customers leave, investors lose confidence, the team burns out, the category moves on, and we learn a valuable lesson.
+**Exception:** Use a worst-case scenario in structured risk work when assumptions, likelihood, impact, and mitigation are explicit.
+**Good use:** Worst credible case for the migration: the primary and replica both accept corrupt writes for 20 minutes; probability is below 1%, and the mitigation is a read-only cutover with snapshot rollback.
+---
+## 194. Best-Case Scenario
+**What it is:** Paired with worst-case to frame range.
+**Why AI may reach for it:** “Best-case scenario” makes upside vivid and can quietly turn an outer bound into an expected result. AI uses it to motivate action without stating the conditions or probability needed to reach the outcome.
+**Three typical AI examples:**
+- “Best-case scenario, you unlock a new growth channel.”
+- “Best-case scenario, you double your retention.”
+- “Best-case scenario, your brand becomes the default.”
+**How to spot it:** Cue: a best case containing dramatic growth, virality, dominance, or transformation. Check assumptions, base rate, probability, and whether the decision survives a median case. Falsification test: if the upside is explicitly bounded and separated from the forecast, it is valid scenario planning.
+**The ugly version:** Best-case scenario, this one post goes viral, attracts the perfect investors, doubles revenue, defines the category, and makes every future campaign easier.
+**Exception:** Use a best-case scenario as an explicit outer bound with stated conditions and probability, not as the expected outcome.
+**Good use:** Best case, if all three enterprise pilots convert, annual recurring revenue rises by £360,000; the forecast counts one conversion, based on our 35% pilot rate.
+---
+## 195. The Stakes Are High
+**What it is:** Drama phrase for decision significance.
+**Why AI may reach for it:** “The stakes are high” announces consequence without naming who can lose what, how likely the loss is, or whether the decision is reversible. AI uses the phrase to create urgency before doing risk analysis.
+**Three typical AI examples:**
+- “The stakes are high when you reposition publicly.”
+- “The stakes are high when you raise prices.”
+- “The stakes are high when you change your promise.”
+**How to spot it:** Cue: the phrase beside a launch, rebrand, price change, or strategic choice. Ask for affected parties, downside, probability, reversibility, and deadline. Falsification test: if those details show material, time-sensitive harm, “high stakes” accurately summarizes the situation.
+**The ugly version:** The stakes are high: choose the wrong shade of blue and you could lose customer trust, market relevance, employee confidence, and the future of the company.
+**Exception:** Use the phrase when material consequences, affected parties, reversibility, and decision timing are all explicit.
+**Good use:** The stakes are high because the valve controls oxygen to 42 patients, a mistaken closure causes immediate harm, and the action cannot be reversed remotely.
+---
+## 196. It All Comes Down To
+**What it is:** Reduction phrase that boils everything into one factor.
+**Why AI may reach for it:** “It all comes down to” collapses a multi-causal problem into one decisive factor. AI reaches for the reduction because it produces a clean conclusion even when other variables remain active.
+**Three typical AI examples:**
+- “It all comes down to whether people trust you.”
+- “It all comes down to a simple, believable promise.”
+- “It all comes down to whether you show up consistently.”
+**How to spot it:** Cue: the phrase followed by one trait, metric, choice, or principle. Search for omitted necessary conditions and counterexamples where the factor is present but the result differs. Falsification test: if analysis within a defined scope shows one binding constraint while others are held constant, the reduction is legitimate.
+**The ugly version:** Product success involves research, engineering, pricing, support, distribution, timing, and cash—but it all comes down to believing in your story.
+**Exception:** Use the reduction for a demonstrated binding constraint within a clearly bounded decision.
+**Good use:** Both bids meet the technical and delivery requirements, so this award comes down to audited five-year cost: £4.2 million versus £4.8 million.
+---
+## 197. At First, It Might Seem
+**What it is:** Hedge around potentially counterintuitive points.
+**Why AI may reach for it:** “At first, it might seem” creates a presumed naïve reading that the writer can overturn. AI uses it to manufacture a reveal even when readers would not naturally hold the opening assumption.
+**Three typical AI examples:**
+- “At first, it might seem risky to niche down.”
+- “At first, it might seem odd to shrink your offer.”
+- “At first, it might seem like overkill to send more emails.”
+**How to spot it:** Cue: the phrase introduces an allegedly obvious view, followed by “but,” “however,” or a deeper truth. Ask whether real readers make that mistake and what evidence reverses it. Falsification test: if user research, prior literature, or a visible first reading supports the misconception, the setup helps orient the correction.
+**The ugly version:** At first, it might seem that charging customers more would increase revenue, but on closer inspection the deeper truth is that pricing is really a story about courage.
+**Exception:** Use the setup when a documented first impression differs from the evidence-supported interpretation.
+**Good use:** At first, the chart seems to show complaints doubling, but the reporting population tripled; complaints per 1,000 users actually fell from 8 to 5.
+---
+## 198. You Might Be Tempted To
+**What it is:** Pre-empting a “wrong” instinct before correcting it.
+**Why AI may reach for it:** “You might be tempted to” invents an impulse for the reader and gives AI an easy wrong-turn/correction sequence. The model can sound anticipatory without evidence that anyone faces that choice.
+**Three typical AI examples:**
+- “You might be tempted to add more features.”
+- “You might be tempted to chase new channels.”
+- “You might be tempted to copy competitors.”
+**How to spot it:** Cue: second-person temptation followed by a warning and preferred alternative. Look for behavioural evidence, a real decision point, and the cost of the tempting option. Falsification test: if the audience commonly chooses that option and the passage explains why it fails here, the anticipation is useful.
+**The ugly version:** You might be tempted to ask customers what they need, examine the data, or test a smaller change—but resist that instinct and trust the bold vision instead.
+**Exception:** Use it for a documented, plausible decision path when explaining a specific hidden cost or constraint.
+**Good use:** You might be tempted to retry the import immediately, but the first attempt can still be processing; check the job ID before creating a duplicate.
+---
+## 199. It Can Be Tempting To
+**What it is:** Variation of the temptation pattern.
+**Why AI may reach for it:** “It can be tempting to” performs the same pre-emption without directly accusing the reader. AI uses the impersonal phrasing to create a safe correction arc around advice that may not match the actual decision.
+**Three typical AI examples:**
+- “It can be tempting to lower prices.”
+- “It can be tempting to imitate bigger brands.”
+- “It can be tempting to hide behind jargon.”
+**How to spot it:** Cue: an unspecified “tempting” action followed by “but.” Ask who faces the temptation, under what pressure, and what evidence shows the alternative is better. Falsification test: if the trade-off is real and the passage identifies the condition that makes the tempting choice harmful, the wording earns its place.
+**The ugly version:** It can be tempting to lower prices when sales fall, but the braver move is always to raise them, narrow the audience, and trust that premium buyers will appear.
+**Exception:** Use it when a credible short-term incentive leads toward a documented longer-term cost.
+**Good use:** It can be tempting to skip the backup test to meet Friday’s release, but the last untested restore added nine hours to the outage.
+---
+## 200. More Often Than You Think
+**What it is:** Claiming frequency without evidence.
+**Why AI may reach for it:** “More often than you think” claims both a frequency and a mismatch with the reader’s belief. AI can supply neither denominator nor evidence about what the reader thinks while still making the claim feel surprising.
+**Three typical AI examples:**
+- “Churn happens faster than you think.”
+- “People forget your brand more often than you think.”
+- “Your best customers are lurking more often than you think.”
+**How to spot it:** Cue: “more often than you think,” “faster than you think,” or “more common than most realize.” Demand an observation window, denominator, comparison rate, and evidence of the expected belief. Falsification test: if measured frequency exceeds a named forecast or survey estimate, the comparison is supportable.
+**The ugly version:** Your best customers are lurking more often than you think, buying sooner than you expect, sharing more than you realize, and waiting for exactly the message you have not sent.
+**Exception:** Use the phrase when measured frequency can be compared with a documented expectation from the same audience.
+**Good use:** Password reuse is more common than this team estimated: the survey prediction was 20%, while the audit found it in 46 of 100 test accounts.
+---
+# Patterns 201–220
+## 201. Before You Know It
+**What it is:** Time-acceleration phrase.
+**Why AI may reach for it:** “Before you know it” compresses an unspecified period and removes the steps between action and outcome. AI uses it to make consequences feel automatic, fast, and inevitable.
+**Three typical AI examples:**
+- “Before you know it, your list will be full of the wrong people.”
+- “Before you know it, you’re shipping features nobody uses.”
+- “Before you know it, your brand feels like everyone else’s.”
+**How to spot it:** Cue: the phrase connecting a small action to a future problem or success. Ask how long the process takes, which intermediate events occur, and what could interrupt it. Falsification test: if the timing and chain can be stated, state them; if not, the phrase is manufacturing inevitability.
+**The ugly version:** Post without a strategy and, before you know it, your audience is wrong, your offer is diluted, your team is confused, and your entire brand has become impossible to repair.
+---
+## 202. In the Blink of an Eye
+**What it is:** Overly dramatic speed metaphor.
+**Why AI may reach for it:** “In the blink of an eye” turns any fast change into instantaneous drama. AI can imply speed and fragility without reporting the actual interval or the process that caused the change.
+**Three typical AI examples:**
+- “Reputation can shift in the blink of an eye.”
+- “A bad experience can spread in the blink of an eye.”
+- “Trends can change in the blink of an eye.”
+**How to spot it:** Cue: the phrase attached to reputation, trends, markets, trust, or customer behaviour. Replace it with the elapsed time and event sequence. Falsification test: if the literal duration is important and extremely short, the number is more informative than the metaphor.
+**The ugly version:** In the blink of an eye, one typo can destroy your reputation, erase years of trust, trigger a global backlash, and hand the market to your competitors.
+---
+## 203. At First Glance vs On Closer Inspection
+**What it is:** Double-vision phrase contrasting surface with depth.
+**Why AI may reach for it:** The first-glance/closer-inspection frame gives AI a built-in reveal: a simple initial reading becomes a deeper diagnosis. It can invent both readings without identifying what new observation changed the conclusion.
+**Three typical AI examples:**
+- “At first glance, it looks like a traffic problem; on closer inspection, it’s an offer problem.”
+- “At first glance, the campaign seems strong; on closer inspection, the message is muddy.”
+- “At first glance, churn looks random; on closer inspection, it isn’t.”
+**How to spot it:** Cue: “at first glance” paired with “on closer inspection.” Name the initial evidence, the additional evidence, and the inference that changed. Falsification test: if a specific inspection genuinely overturns the first reading, the contrast documents analysis rather than staging depth.
+**The ugly version:** At first glance, falling sales look like a demand problem; on closer inspection, beneath the surface, the deeper reality is an invisible crisis of brand belief.
+**Exception:** Use the frame when a later, specified observation materially changes a plausible initial interpretation.
+**Good use:** At first glance, the crack looks cosmetic; under magnification, it crosses the solder joint and breaks continuity when the board flexes.
+---
+## 204. Not All X Are Created Equal
+**What it is:** Cliché equality framing.
+**Why AI may reach for it:** “Not all X are created equal” announces variation as if it were a discovery, then often avoids naming the dimensions that differ. AI uses the cliché to set up ranking or segmentation without criteria.
+**Three typical AI examples:**
+- “Not all leads are created equal.”
+- “Not all channels are created equal.”
+- “Not all customers are created equal.”
+**How to spot it:** Cue: the exact phrase before a list, product comparison, or sales claim. Ask which attribute varies, how it is measured, and whether the groups share the same purpose. Falsification test: if the passage immediately supplies relevant criteria and evidence, the phrase can introduce a real comparison; otherwise it is an empty truism.
+**The ugly version:** Not all leads are created equal: some are warm, some are cold, some are high quality, and some simply lack the premium energy your sales team deserves.
+**Exception:** Use the phrase only when the following comparison defines the relevant dimensions and supports them with evidence.
+**Good use:** Not all backup copies are created equal: the local copy shares the building’s fire risk, while the off-site copy was restored successfully in last week’s test.
+---
+## 205. There’s a Fine Line Between
+**What it is:** Cliché tension framing.
+**Why AI may reach for it:** “There’s a fine line between” creates tension between two categories while leaving the boundary undefined. AI can sound discerning without telling the reader how to classify a borderline case.
+**Three typical AI examples:**
+- “There’s a fine line between confidence and arrogance.”
+- “There’s a fine line between urgency and pressure.”
+- “There’s a fine line between consistency and spam.”
+**How to spot it:** Cue: the phrase joining desirable and undesirable states such as confidence/arrogance or urgency/pressure. Ask for observable criteria on each side and a borderline example. Falsification test: if a real threshold is difficult but consequential and the writer supplies decision criteria, the phrase summarizes a useful distinction.
+**The ugly version:** There’s a fine line between confidence and arrogance, urgency and pressure, consistency and spam, leadership and control, and persuasion and manipulation—use your judgment.
+**Exception:** Use the phrase when a consequential boundary is genuinely hard to judge and the passage gives criteria for both sides.
+**Good use:** There is a fine line between a reminder and harassment in this policy: a second message after seven days is allowed; contacting another address after an opt-out is not.
+---
+## 206. The Line Between X and Y Is Blurry
+**What it is:** Ambiguity cliché.
+**Why AI may reach for it:** “The line is blurry” declares categories overlapping without identifying the dimensions of overlap. AI uses ambiguity as a conclusion, which can excuse the writer from defining terms or making a decision.
+**Three typical AI examples:**
+- “The line between brand and product is blurry.”
+- “The line between content and sales is blurry.”
+- “The line between storytelling and manipulation is blurry.”
+**How to spot it:** Cue: “the line between X and Y is blurry/blurring.” Ask where the categories clearly differ, where they overlap, and why the overlap matters. Falsification test: if shared attributes create genuine classification uncertainty and the consequences are explained, “blurry” is accurate.
+**The ugly version:** The line between content and sales is blurry, the line between brand and product is blurry, and the line between insight and empty abstraction is also becoming increasingly blurry.
+**Exception:** Use the description when categories genuinely overlap along named dimensions and the ambiguity affects a decision.
+**Good use:** The line between contractor and employee is blurry here: the designer chooses her hours but works exclusively on company equipment under a staff manager.
+---
+## 207. Whether You Realize It or Not
+**What it is:** Asserting unconscious behavior.
+**Why AI may reach for it:** “Whether you realize it or not” asserts an unconscious effect and makes disagreement sound like proof of ignorance. AI uses it to give ordinary claims an unavoidable, personal edge.
+**Three typical AI examples:**
+- “Whether you realize it or not, you’re training your audience.”
+- “Whether you realize it or not, your pricing sends a signal.”
+- “Whether you realize it or not, your default tone teaches people how to treat you.”
+**How to spot it:** Cue: the phrase before a claim about what the reader is doing, signalling, teaching, or becoming. Look for evidence of the automatic process and whether it applies to this reader. Falsification test: if the effect is technically automatic and independently verifiable, awareness truly is irrelevant; otherwise the phrase is presumptuous.
+**The ugly version:** Whether you realize it or not, every colour, pause, typo, price, emoji, silence, and delayed reply is training the market to decide exactly what your brand is worth.
+**Exception:** Use it sparingly for an automatic, verifiable process whose operation does not depend on the reader’s awareness.
+**Good use:** Whether you realize it or not, opening this spreadsheet recalculates every volatile formula; the status bar shows the process.
+---
+## 208. Like It or Not
+**What it is:** Asserting inevitability.
+**Why AI may reach for it:** “Like it or not” frames a claim as inevitable and pre-dismisses objection as mere preference. AI can make a debatable opinion sound like an external constraint.
+**Three typical AI examples:**
+- “Like it or not, people judge you by your first impression.”
+- “Like it or not, your brand is a filter.”
+- “Like it or not, your category shapes expectations.”
+**How to spot it:** Cue: the phrase before a prediction, norm, or judgment. Separate facts outside the reader’s control from the writer’s preferred interpretation. Falsification test: if a rule or event applies regardless of preference and is independently verifiable, the inevitability is real.
+**The ugly version:** Like it or not, everyone is a personal brand, every employee is a creator, every company is a media company, and anyone who disagrees is already behind.
+**Exception:** Use it only when a documented external condition applies regardless of preference; do not use it to bully agreement with an opinion.
+**Good use:** Like it or not, the old certificate expires at midnight UTC; clients that have not installed the replacement will lose access.
+---
+## 209. Ready or Not
+**What it is:** Similar inevitability framing.
+**Why AI may reach for it:** “Ready or not” combines inevitability with a deadline but often omits the event, authority, and preparation gap. AI uses it to create pressure around trends that are neither scheduled nor universal.
+**Three typical AI examples:**
+- “Ready or not, AI is part of your workflow.”
+- “Ready or not, your audience compares you globally.”
+- “Ready or not, someone is telling a sharper story.”
+**How to spot it:** Cue: “ready or not” before AI, competition, change, or disruption. Ask what happens, on which date, to whom, and under whose control. Falsification test: if a fixed event will occur regardless of readiness, the phrase can accurately warn; if timing is speculative, it is manufactured urgency.
+**The ugly version:** Ready or not, AI is transforming every job, every market, every relationship, and every human skill immediately—so adopt the latest tools before readiness becomes irrelevant.
+**Exception:** Use it for a fixed, unavoidable event when the audience still has a concrete preparation window.
+**Good use:** Ready or not, the evacuation drill begins at 10:00; ward leads have 20 minutes to check their lists and assign escorts.
+---
+## 210. The Hard Part Isn’t X, It’s Y
+**What it is:** Variant of It’s Not X, It’s Y specifically about difficulty.
+**Why AI may reach for it:** “The hard part isn’t X, it’s Y” gives AI a crisp bottleneck diagnosis by demoting one difficulty and elevating another. The symmetry can hide that both are hard or that no evidence ranks them.
+**Three typical AI examples:**
+- “The hard part isn’t getting attention; it’s keeping it.”
+- “The hard part isn’t ideas; it’s execution.”
+- “The hard part isn’t traffic; it’s trust.”
+**How to spot it:** Cue: the exact contrast around two tasks or constraints. Check failure data, time spent, drop-off, or dependency evidence for which part actually binds. Falsification test: if X is demonstrably solved or held constant and Y explains most remaining failure, the contrast is earned.
+**The ugly version:** The hard part isn’t building a useful product, finding customers, pricing it, supporting it, or surviving; it’s believing deeply enough in the story you tell.
+**Exception:** Use the frame when evidence identifies Y as the binding constraint after X has been met or controlled.
+**Good use:** The hard part is not collecting applications—we receive 900 a week. It is review capacity: two staff can assess only 180.
+---
+## 211. The Point Isn’t X, It’s Y
+**What it is:** Meta correction phrase often used in AI-style explanations.
+**Why AI may reach for it:** “The point isn’t X, it’s Y” lets AI redirect interpretation without showing that anyone claimed X or that Y follows from the evidence. The sentence sounds decisive because its two halves are balanced.
+**Three typical AI examples:**
+- “The point isn’t more content; it’s better content.”
+- “The point isn’t more followers; it’s more buyers.”
+- “The point isn’t speed; it’s direction.”
+**How to spot it:** Cue: the phrase in an explanation, conclusion, or rebuttal. Identify the interpretation being corrected, its source, and the evidence for the replacement. Falsification test: if a real misunderstanding is on record and Y states the intended conclusion accurately, the correction is useful.
+**The ugly version:** The point isn’t whether the campaign made money, reached the right people, or taught us anything; the point is that we showed up with courage.
+**Exception:** Use it to correct a specific, evidenced misreading—not to dismiss an inconvenient criterion.
+**Good use:** The point is not that the drug never works; the trial shows that its benefit disappears when treatment starts more than 48 hours after symptoms.
+---
+## 212. You Don’t Need X, You Need Y
+**What it is:** Replacement pattern that swaps assumed solution with “real” one.
+**Why AI may reach for it:** “You don’t need X, you need Y” gives AI a forceful replacement diagnosis without examining whether X and Y are complementary. It creates certainty by treating an additive problem as a binary choice.
+**Three typical AI examples:**
+- “You don’t need more tools; you need more conviction.”
+- “You don’t need a rebrand; you need a clear promise.”
+- “You don’t need more leads; you need better fits.”
+**How to spot it:** Cue: second-person replacement language around tools, leads, content, strategy, confidence, or clarity. Test whether X is absent, whether Y addresses the same problem, and whether both may be required. Falsification test: if evidence shows X cannot solve the diagnosed problem and Y directly addresses the cause, the correction is valid.
+**The ugly version:** You don’t need research, more customers, a stable product, or working analytics; you need conviction, consistency, courage, and a clearer personal brand.
+**Exception:** Use the pattern when the requested solution cannot address the demonstrated cause and the replacement can.
+**Good use:** You do not need another password reset; the account is locked by an unpaid invoice, so you need the billing administrator to restore access.
+---
+## 213. You Don’t Have to X
+**What it is:** Reassuring removal of perceived burden.
+**Why AI may reach for it:** “You don’t have to” offers relief by inventing a burden and removing it. AI uses the reassuring frame to sound supportive before establishing that the reader feels pressured or that the alternative is safe.
+**Three typical AI examples:**
+- “You don’t have to post daily to grow.”
+- “You don’t have to be everywhere at once.”
+- “You don’t have to shout to be heard.”
+**How to spot it:** Cue: reassurance about posting, visibility, productivity, perfection, or doing everything. Ask whether the audience reported the burden and whether evidence supports the proposed minimum. Falsification test: if a real requirement has been misunderstood and the writer can state the actual threshold, the relief is useful.
+**The ugly version:** You don’t have to work harder, post daily, build expertise, understand your customers, or improve the product—you only have to tell a story people want to believe.
+**Exception:** Use it to correct a documented false requirement or to remove a burden the audience has explicitly expressed.
+**Good use:** You don’t have to submit the form again; your first application is active until 30 September, and the reference number remains valid.
+---
+## 214. You’re Still Early
+**What it is:** Comforting phrase about timing.
+**Why AI may reach for it:** “You’re still early” reassures the reader about timing while avoiding adoption data, market maturity, or a definition of early. AI can make any opportunity feel open and reduce fear of missing out without evidence.
+**Three typical AI examples:**
+- “You’re still early to long-form content.”
+- “You’re still early if you’re just starting your list.”
+- “You’re still early to treating brand as a moat.”
+**How to spot it:** Cue: “still early” attached to a platform, technology, market, or personal project. Ask early by which measure: adoption, revenue, penetration, standards, or time since launch? Falsification test: if a relevant adoption curve and comparison threshold place the subject in an early stage, the claim is supportable.
+**The ugly version:** You’re still early to AI, newsletters, communities, video, personal branding, and every other opportunity—provided you buy the course before everyone else realizes how early it is.
+**Exception:** Use “early” when a defined adoption or development measure places the subject in an initial stage.
+**Good use:** Grid-scale sodium batteries are still early in deployment: fewer than 2 GWh are operating worldwide, compared with more than 150 GWh of lithium-ion storage.
+---
+## 215. It’s Still Day One
+**What it is:** Borrowed startup phrase reused in generic contexts.
+**Why AI may reach for it:** “It’s still day one” borrows a startup slogan to imply limitless possibility, permanent urgency, and freedom from mature expectations. AI can apply it to an old or undefined initiative without stating what has actually begun.
+**Three typical AI examples:**
+- “It’s still day one for AI-assisted branding.”
+- “It’s still day one for your newsletter.”
+- “It’s still day one for your category’s story.”
+**How to spot it:** Cue: “day one” used metaphorically years after launch or without a milestone. Ask which project began, on what date, and what phase follows. Falsification test: if it is literally the first day or a formally defined restart, the phrase is factual; otherwise it is borrowed optimism.
+**The ugly version:** After nine years, five rebrands, three failed migrations, and a mature customer base, it is still day one for our category, our culture, our product, and our learning journey.
+**Exception:** Use it literally for the first day of a defined initiative or explicitly as a quoted organizational motto.
+**Good use:** It is day one of the six-week pilot: the first 40 participants received devices this morning, and baseline measurements begin at noon.
+---
+## 216. The Best Time Was X, the Second-Best Time Is Now
+**What it is:** Stock timing proverb.
+**Why AI may reach for it:** The “best time/second-best time” proverb turns regret into immediate action and treats timing as universally favourable now. AI uses it to close deliberation without checking whether prerequisites, risk, or a better future window matter.
+**Three typical AI examples:**
+- “The best time to start your list was last year; the second-best time is now.”
+- “The best time to raise prices was before inflation; the second-best time is now.”
+- “The best time to define your positioning was at launch; the second-best time is now.”
+**How to spot it:** Cue: the stock proverb applied to pricing, investing, publishing, hiring, or launching. Ask whether “now” is actually preferable to waiting and what conditions must be met first. Falsification test: if timing does not materially affect safety or outcome and delay has a clear cost, direct advice with those facts is stronger than the proverb.
+**The ugly version:** The best time to launch was before you understood the market; the second-best time is now, before research, testing, legal review, or doubt can slow your momentum.
+---
+## 217. Only Time Will Tell
+**What it is:** Non-committal future uncertainty cliché.
+**Why AI may reach for it:** “Only time will tell” lets AI end at uncertainty without naming what remains unknown, which evidence will resolve it, or when a decision can be made. The cliché sounds prudent while avoiding a forecast or monitoring plan.
+**Three typical AI examples:**
+- “Only time will tell whether this bet pays off.”
+- “Only time will tell which brands survive.”
+- “Only time will tell if this channel sticks.”
+**How to spot it:** Cue: the phrase as the final sentence after a prediction or strategic choice. Ask what outcome will be observed, by which date, and against what threshold. Falsification test: if the outcome is genuinely future-dependent and the passage specifies the observation plan, the phrase may honestly mark the limit.
+**The ugly version:** Only time will tell whether the launch works, whether customers care, whether the channel survives, whether the strategy makes sense, or whether any of our assumptions were remotely correct.
+**Exception:** Use it for a genuinely unresolved future outcome only when the evidence and review date are named.
+**Good use:** Only time will tell whether immunity lasts beyond two years; the cohort will be retested every six months through June 2028.
+---
+## 218. At First, I Was Skeptical, But
+**What it is:** Personal skepticism flipped to endorsement.
+**Why AI may reach for it:** The skepticism-to-endorsement arc gives AI instant narrative credibility: a doubtful first-person witness appears to have tested the idea and changed their mind. A model can generate the shape without having an experience.
+**Three typical AI examples:**
+- “At first, I was skeptical about niching down, but it clarified everything.”
+- “At first, I was skeptical about email, but it became our main driver.”
+- “At first, I was skeptical about AI, but it sped things up.”
+**How to spot it:** Cue: “at first I was skeptical, but…” followed by praise and no dated observation. Verify authorship, the initial objection, what was tried, and what evidence changed the view. Falsification test: if a real person can document the experience and names the disconfirming evidence, the arc is legitimate.
+**The ugly version:** At first, I was skeptical about AI, but after watching it transform my workflow, deepen my creativity, strengthen my relationships, and unlock my potential, I became a lifelong believer.
+**Exception:** A human writer may use the arc for a real change of mind supported by specific experience. AI must not invent first-person skepticism or results.
+**Good use:** At first I was skeptical that the shorter form would reduce abandonment; after the A/B test showed completion rising from 41% to 68% across 12,000 visits, I changed my view.
+---
+## 219. You Won’t Believe X
+**What it is:** Clickbait disbelief hook.
+**Why AI may reach for it:** “You won’t believe” withholds the fact and tells the reader how surprised to feel. AI uses the curiosity gap because it can generate attention before producing a result strong enough to deserve it.
+**Three typical AI examples:**
+- “You won’t believe what happened when we raised prices.”
+- “You won’t believe how few subscribers drive most revenue.”
+- “You won’t believe how simple the winning email was.”
+**How to spot it:** Cue: the hook delays a number, event, or conclusion that could fit in the headline. Reveal the fact and see whether interest survives. Falsification test: if the direct result is clear and compelling, the disbelief instruction adds nothing; if the result is weak, the hook was compensating.
+**The ugly version:** You won’t believe what happened when we changed one button—and the shocking, jaw-dropping, almost unbelievable result will completely transform how you think about buttons forever.
+---
+## 220. The Results Speak for Themselves
+**What it is:** Self-justifying phrase instead of showing data.
+**Why AI may reach for it:** “The results speak for themselves” lets AI claim validation while omitting the metric, baseline, timeframe, sample, and method. It converts evidence from something the writer must present into something the reader is told to assume.
+**Three typical AI examples:**
+- “The results speak for themselves: churn dropped.”
+- “The results speak for themselves: revenue doubled.”
+- “The results speak for themselves: replies went up.”
+**How to spot it:** Cue: the phrase beside vague changes such as “revenue grew,” “engagement improved,” or “customers loved it.” Inspect the surrounding text for numbers, comparison, time window, sample, and attribution. Falsification test: if all evidence is already visible and the phrase merely closes an informal summary, it may be harmless—though the data usually make it redundant.
+**The ugly version:** The results speak for themselves: engagement soared, trust deepened, customers were delighted, the team felt energized, and the business entered a stronger position by every measure that matters.
+**Exception:** It can close an informal summary after the relevant evidence, baseline, timeframe, and method have already been presented.
+**Good use:** After 18,400 sessions, completion rose from 52% to 71%, median time fell by 34 seconds, and error reports did not increase. In this case, the results speak for themselves.# Research notes
+- [NIST, Reducing Risks Posed by Synthetic Content (2024)](https://doi.org/10.6028/NIST.AI.100-4)
+- [OpenAI, New AI classifier for indicating AI-written text (withdrawn in 2023)](https://openai.com/index/new-ai-classifier-for-indicating-ai-written-text/)
+- [Sadasivan et al., Can AI-Generated Text be Reliably Detected? (2025)](https://openreview.net/forum?id=OOgsAZdFOt)
+- [Dugan et al., RAID benchmark (ACL 2024)](https://aclanthology.org/2024.acl-long.674/)
+- [Liang et al., GPT detectors are biased against non-native English writers (2023)](https://pmc.ncbi.nlm.nih.gov/articles/PMC10382961/)
+- [Weber-Wulff et al., Testing of detection tools for AI-generated text (2023)](https://link.springer.com/article/10.1007/s40979-023-00146-z)
+- [Kobak et al., excess vocabulary in LLM-assisted biomedical writing (2025)](https://pmc.ncbi.nlm.nih.gov/articles/PMC12219543/)
+- [Gao et al., ChatGPT abstracts and blinded human review (2023)](https://www.nature.com/articles/s41746-023-00819-6)
+- [WHO, Use plain language](https://www.who.int/about/communications/understandable/plain-language)
+- [CDC/ATSDR, Tips for Preparing Written Documents](https://www.atsdr.cdc.gov/pha-guidance/putting_it_all_together/tips-for-preparing-written-documents.html)
+- [Purdue OWL, Organization at the Paragraph Level (2024)](https://owl.purdue.edu/owl/graduate_writing/introduction_to_writing/documents/drafting-your-document/organization-at-the-paragraph-level.pdf)
+- [FTC, Advertising FAQs](https://www.ftc.gov/business-guidance/resources/advertising-faqs-guide-small-business)
+## Editorial boundary
+This guide catalogues recurring writing habits. It is not a detector, probability score, misconduct test, or substitute for provenance. Any authorship judgment needs evidence outside the prose itself.
+


### PR DESCRIPTION
Adds the owner-authored canonical 220-pattern editorial guide recovered from Notion. The guide is explicitly separated from the smaller tested automated ruleset, so it is not misrepresented as 220 executable regexes or an authorship detector.\n\nVerification: npm test; npm run check:release.