### PR TITLE
feat: add tiered prompts and 13-element VoiceDNA

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: shashank-sn

--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
-# holdyourvoice
+# Hold Your Voice
 
-A local-first writing gate with two separate opinions about a draft:
+An MIT-licensed, local-first writing gate that checks two different problems without blending them into one opaque score.
 
-- **VoiceDNA** measures drift from a profile built from your own local samples.
-- **AI Editor** flags versioned, generic AI-writing patterns.
+- **VoiceDNA** compares a draft with 13 observable elements from your local writing samples.
+- **AI Editor** flags versioned editorial patterns that make writing generic, formulaic, or needlessly inflated.
 
-They never share a score. `analyze` reports both; `rewrite-prompt` turns both evidence sets into one bounded editing brief; `verify` re-runs both engines and fails when either gate fails, a critical regression appears, or key terms disappear.
+The output is a tiered rewrite brief. A candidate rewrite must pass both engines again before it is accepted.
+
+## What it does
+
+| Command | Outcome |
+| --- | --- |
+| `profile` | Builds a portable VoiceDNA JSON profile from two or more local samples. |
+| `analyze` | Returns separate VoiceDNA and AI Editor scores, findings, and pass states. |
+| `rewrite-prompt` | Produces a priority-ordered editing brief for your chosen model or human editor. |
+| `verify` | Rechecks a candidate, reports regressions, and exits non-zero when the dual gate fails. |
+| `patterns` | Prints the deterministic AI Editor rules currently enabled. |
+
+No account, API, MCP server, telemetry, payment collection, or network request is part of the runtime.
 
 ## Quick start
 
@@ -18,22 +30,35 @@ npx holdyourvoice rewrite-prompt draft.md profile.json > rewrite-brief.md
 npx holdyourvoice verify draft.md candidate.md profile.json
 ```
 
-No account, API, MCP server, telemetry, or network request is part of this project.
+## The rewrite brief
 
-## How it works
+The prompt is deliberately ordered. Lower tiers never override a higher tier.
 
-```mermaid
-flowchart TB
-  A[Local samples] --> B[VoiceDNA profile]
-  C[Draft] --> D[VoiceDNA score]
-  C --> E[AI Editor score]
-  B --> D
-  D --> F[Rewrite brief]
-  E --> F
-  G[Candidate] --> H[Dual post-rewrite gate]
-```
+1. **Tier 0 — preservation:** facts, names, numbers, and clean sentences stay intact.
+2. **Tier 1 — blockers:** avoid-list violations and red findings must be fixed.
+3. **Tier 2 — VoiceDNA:** 13 profile elements provide the writer-specific target.
+4. **Tier 3 — AI Editor:** yellow findings offer precise editorial improvements.
+5. **Tier 4 — output:** only targeted replacement sentences are returned.
 
-Read [the thesis](docs/THESIS.md), [architecture](docs/ARCHITECTURE.md), [VoiceDNA reference](docs/VOICE-DNA.md), the [full 220-pattern editorial catalog](docs/patterns/AI-WRITING-PATTERNS-1-220.md), [pattern taxonomy](docs/PATTERN-TAXONOMY.md), and [benchmark policy](docs/BENCHMARKS.md) before extending the gate.
+This is a prompt generator, not a hosted model. Bring any model or editor you trust, then run `verify` on the result. Read the [full prompt contract](docs/PROMPT-CONTRACT.md) before changing prompt order.
+
+## VoiceDNA
+
+The profile captures sentence length, sentence variation, sentence structure, rhythm, paragraph length, opening moves, vocabulary, lexical density, point of view, punctuation, case style, question rate, and transitions. Read the full [VoiceDNA reference](docs/VOICE-DNA.md).
+
+## Pattern catalog and safe automation
+
+The owner-authored [220-pattern editorial catalog](docs/patterns/AI-WRITING-PATTERNS-1-220.md) is the complete reference. It includes spotting tests, ugly escalations, and legitimate exceptions. It is not an AI-authorship detector.
+
+The automated ruleset is intentionally smaller: a catalog pattern becomes executable only after deduplication, counterexamples, public provenance review, and tests. That keeps the CLI honest about what it can reliably flag.
+
+## Support
+
+Hold Your Voice stays fully open source. [Sponsor its maintenance on GitHub](https://github.com/sponsors/shashank-sn) with a one-time or recurring sponsorship. Sponsorship does not unlock features, collect donor data here, or alter the privacy contract. See [SUPPORT.md](SUPPORT.md).
+
+## Contributing and design docs
+
+Read [the thesis](docs/THESIS.md), [architecture](docs/ARCHITECTURE.md), [pattern taxonomy](docs/PATTERN-TAXONOMY.md), [benchmark policy](docs/BENCHMARKS.md), and [SUPPORT.md](SUPPORT.md) before contributing.
 
 ## Privacy and data rights
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,7 @@
+# Support Hold Your Voice
+
+Hold Your Voice is MIT-licensed and stays fully usable without payment. Sponsorship funds maintenance, rule research, documentation, reproducible evaluations, and accessibility work. It never unlocks product features or changes the local-first privacy contract.
+
+Support the project through [GitHub Sponsors](https://github.com/sponsors/shashank-sn). GitHub handles one-time and recurring sponsorship tiers; this repository does not collect payments or donor information.
+
+The most useful non-financial support is a reproducible bug report, a tested rule proposal with counterexamples, documentation improvements, or a synthetic/author-owned evaluation fixture.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,5 @@
 # Architecture
 
-`text.ts` establishes stable sentence indices. `voice-dna.ts` builds and evaluates profiles. `ai-editor.ts` owns the public ruleset. `pipeline.ts` composes reports, produces the rewrite brief, and performs post-rewrite verification. `cli.ts` is a file/stdin-only adapter.
+`text.ts` establishes stable sentence indices and text measurements. `voice-dna.ts` builds 13-element profiles and evaluates the explicitly automated VoiceDNA checks. `ai-editor.ts` owns the public deterministic ruleset. `pipeline.ts` composes reports, produces the priority-tiered rewrite brief, and performs post-rewrite verification. `cli.ts` is a file/stdin-only adapter.
 
-Only `pipeline.ts` combines outputs. It may combine pass states, but it must not combine or overwrite engine scores. Add a new rule only in `ai-editor.ts`, with a test and documentation entry. Add a new VoiceDNA signal only in `voice-dna.ts`, with an explanation that makes it auditable.
+Only `pipeline.ts` combines outputs. It may combine pass states, but it must not combine or overwrite engine scores. Add a new rule only in `ai-editor.ts`, with a test and documentation entry. Add a new VoiceDNA signal only in `voice-dna.ts`, with an explanation that makes it auditable. The [prompt contract](PROMPT-CONTRACT.md) owns tier ordering; do not place a new instruction above preservation without changing that contract and its tests.

--- a/docs/PROMPT-CONTRACT.md
+++ b/docs/PROMPT-CONTRACT.md
@@ -1,0 +1,27 @@
+# Tiered prompt contract
+
+`rewrite-prompt` does not ask a model to rewrite freely. It sends evidence in five tiers. A lower tier may refine a higher tier, but never override it.
+
+## Tier 0 — preservation
+
+The model keeps facts, names, numbers, claims, and unflagged sentences unchanged. This prevents a smoother rewrite from changing the assignment or inventing evidence.
+
+## Tier 1 — release blockers
+
+Red findings and the profile avoid list are non-negotiable. The brief shows each affected sentence, the rule, and the repair direction. The post-rewrite gate checks these again.
+
+## Tier 2 — VoiceDNA fidelity
+
+The profile supplies the 13 observable elements of the writer’s mechanics. These are targets, not a request to imitate quirks mechanically. The model repairs only flagged sentences while preserving deliberate variation.
+
+## Tier 3 — AI Editor improvements
+
+Yellow findings are editorial opportunities: formulaic transitions, vague claims, manufactured contrast, and other repeatable patterns. They are not proof of AI use and do not justify changing a clean line.
+
+## Tier 4 — output contract
+
+The response contains only replacements keyed by sentence number. The caller applies them deliberately, then uses `verify` to rerun the two engines and factual-preservation check.
+
+## Why the tiers matter
+
+The order stops an LLM from treating stylistic preferences as permission to alter facts, and stops a generic style rule from overriding a writer’s documented voice. It makes a failed output explainable: the report identifies the engine, rule, sentence, and priority that failed.

--- a/docs/VOICE-DNA.md
+++ b/docs/VOICE-DNA.md
@@ -1,5 +1,27 @@
 # VoiceDNA
 
-Build a profile from at least two author-owned samples. The profile stores aggregate mechanics, not a copy of the samples: average and deviation of sentence-word counts, observed openers, frequent non-stop words, and an optional avoid list.
+VoiceDNA is a local, inspectable reference built from at least two author-owned samples. It does not infer identity, detect authorship, or upload writing. It describes repeatable mechanics that an editor can compare with a draft.
 
-The evaluator flags cadence that moves materially outside the profile and explicit avoid-list phrases. Its score is independent from AI Editor. A profile is a reference for an editor, not proof that a sentence is objectively good or written by a particular person.
+## The 13 elements
+
+| Element | What the profile records | What a drift finding means |
+| --- | --- | --- |
+| 1. Sentence length | Mean words per sentence | The draft compresses or expands beyond the writer’s normal band. |
+| 2. Sentence variation | Spread of sentence lengths | The draft is too even or too erratic for the reference. |
+| 3. Sentence structure | Repeated opening word shapes | The argument starts moving in an unfamiliar way. |
+| 4. Rhythm | Change in length between neighbouring sentences | The beat has flattened or become needlessly choppy. |
+| 5. Paragraph length | Mean sentences per paragraph | The draft’s visual pacing has drifted. |
+| 6. Opening moves | Common first words | The opening enters unlike the reference samples. |
+| 7. Vocabulary | Frequent non-stop words | Familiar concrete language is missing or displaced. |
+| 8. Lexical density | Share of meaningful words | The draft has become unusually generic or compressed. |
+| 9. Point of view | First-, second-, third-person, or mixed | The writer’s normal narrative distance changed. |
+| 10. Punctuation | Counts of selected marks | The draft uses emphasis or pauses unlike the reference. |
+| 11. Case style | Lowercase, standard, or mixed | Capitalization no longer matches the writer’s convention. |
+| 12. Question rate | Share of sentences ending in questions | The draft is asking far more or fewer questions than normal. |
+| 13. Transitions | Recurrent logical connectors | The piece moves between ideas unlike the reference. |
+
+The current gate emits findings for sentence length, avoid-list phrases, question rate, case style, and point of view. The remaining elements are included in the profile and tiered prompt as visible evidence; they become automatic release checks only after a rule has counterexamples and tests.
+
+## Boundaries
+
+VoiceDNA is a comparison tool. A low score means “different from these samples,” not “bad,” “AI-written,” or “not written by this person.” Use it with editorial judgment and preserve deliberate changes.

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,8 +1,62 @@
 export type Severity = 'red' | 'yellow';
 export type Engine = 'voice_dna' | 'ai_editor';
-export interface Sentence { index: number; start: number; end: number; text: string; }
-export interface Finding { engine: Engine; id: string; severity: Severity; sentence: number; excerpt: string; reason: string; suggestion: string; }
-export interface EngineReport { engine: Engine; version: string; score: number; passed: boolean; findings: Finding[]; }
-export interface Profile { version: string; sampleCount: number; averageSentenceWords: number; sentenceDeviation: number; commonOpeners: string[]; preferredWords: string[]; avoid: string[]; }
-export interface Analysis { version: string; voiceDna: EngineReport; aiEditor: EngineReport; passed: boolean; }
-export interface Verification extends Analysis { preservationScore: number; regressions: Finding[]; }
+
+export interface Sentence {
+  index: number;
+  start: number;
+  end: number;
+  text: string;
+}
+
+export interface Finding {
+  engine: Engine;
+  id: string;
+  severity: Severity;
+  sentence: number;
+  excerpt: string;
+  reason: string;
+  suggestion: string;
+}
+
+export interface EngineReport {
+  engine: Engine;
+  version: string;
+  score: number;
+  passed: boolean;
+  findings: Finding[];
+}
+
+export interface VoiceDnaMetrics {
+  sentenceLength: number;
+  sentenceVariation: number;
+  sentenceStructure: string[];
+  rhythm: number;
+  paragraphLength: number;
+  openingMoves: string[];
+  vocabulary: string[];
+  lexicalDensity: number;
+  pointOfView: 'first_person' | 'second_person' | 'third_person' | 'mixed';
+  punctuation: Record<string, number>;
+  caseStyle: 'lowercase' | 'standard' | 'mixed';
+  questionRate: number;
+  transitions: string[];
+}
+
+export interface Profile {
+  version: string;
+  sampleCount: number;
+  metrics: VoiceDnaMetrics;
+  avoid: string[];
+}
+
+export interface Analysis {
+  version: string;
+  voiceDna: EngineReport;
+  aiEditor: EngineReport;
+  passed: boolean;
+}
+
+export interface Verification extends Analysis {
+  preservationScore: number;
+  regressions: Finding[];
+}

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1,5 +1,33 @@
-import test from 'node:test'; import assert from 'node:assert/strict'; import { buildProfile } from './voice-dna.js'; import { analyze, rewritePrompt, verify } from './pipeline.js';
-const profile=buildProfile(['I ship clear ideas. The details stay concrete.','I write short sentences. Then I explain the mechanism.'],['leverage']);
-test('keeps the two engine scores independent',()=>{ const result=analyze('Firstly, we leverage a holistic strategy.',profile); assert.equal(result.aiEditor.passed,false); assert.equal(typeof result.voiceDna.score,'number'); });
-test('creates a combined but sentence-targeted rewrite brief',()=>{ const prompt=rewritePrompt('Firstly, we leverage a holistic strategy.',profile); assert.match(prompt,/VoiceDNA/); assert.match(prompt,/AI Editor/); assert.match(prompt,/Sentence 1/); });
-test('post gate reports a new AI regression',()=>{ const result=verify('I ship clear ideas.','I ship clear ideas — a game-changer.',profile); assert.equal(result.passed,false); assert.ok(result.regressions.length>0); });
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { analyze, rewritePrompt, verify } from './pipeline.js';
+import { buildProfile } from './voice-dna.js';
+
+const profile = buildProfile([
+  'I ship clear ideas. The details stay concrete. I explain the mechanism without fuss.',
+  'I write short sentences. Then I explain the mechanism. My work stays plain and specific.',
+], ['leverage']);
+
+test('keeps the two engine scores independent', () => {
+  const result = analyze('Firstly, we leverage a holistic strategy.', profile);
+  assert.equal(result.aiEditor.passed, false);
+  assert.equal(typeof result.voiceDna.score, 'number');
+});
+
+test('builds all thirteen VoiceDNA measurements', () => {
+  assert.deepEqual(Object.keys(profile.metrics), ['sentenceLength', 'sentenceVariation', 'sentenceStructure', 'rhythm', 'paragraphLength', 'openingMoves', 'vocabulary', 'lexicalDensity', 'pointOfView', 'punctuation', 'caseStyle', 'questionRate', 'transitions']);
+});
+
+test('orders rewrite instructions by importance tier', () => {
+  const prompt = rewritePrompt('Firstly, we leverage a holistic strategy.', profile);
+  assert.ok(prompt.indexOf('# Tier 0') < prompt.indexOf('# Tier 1'));
+  assert.ok(prompt.indexOf('# Tier 1') < prompt.indexOf('# Tier 2'));
+  assert.ok(prompt.indexOf('# Tier 2') < prompt.indexOf('# Tier 3'));
+  assert.ok(prompt.indexOf('# Tier 3') < prompt.indexOf('# Tier 4'));
+});
+
+test('post gate reports a new AI regression', () => {
+  const result = verify('I ship clear ideas.', 'I ship clear ideas — a game-changer.', profile);
+  assert.equal(result.passed, false);
+  assert.ok(result.regressions.length > 0);
+});

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,5 +1,64 @@
-import type { Analysis, Profile, Verification } from './contracts.js'; import { analyzeAiEditor } from './ai-editor.js'; import { analyzeVoiceDna } from './voice-dna.js'; import { words } from './text.js';
-export function analyze(text:string, profile:Profile):Analysis { const voiceDna=analyzeVoiceDna(text,profile), aiEditor=analyzeAiEditor(text); return {version:'1',voiceDna,aiEditor,passed:voiceDna.passed&&aiEditor.passed}; }
-export function rewritePrompt(draft:string, profile:Profile):string { const result=analyze(draft,profile); const findings=[...result.voiceDna.findings,...result.aiEditor.findings]; return ['You are editing a draft. Preserve facts, names, numbers, and every unflagged sentence exactly.','',`VoiceDNA: ${result.voiceDna.score}/100 (${result.voiceDna.passed?'pass':'fail'}).`,`AI Editor: ${result.aiEditor.score}/100 (${result.aiEditor.passed?'pass':'fail'}).`,'','VOICE DNA CONSTRAINTS:',`- Target sentence length: ${profile.averageSentenceWords} words.`,...profile.avoid.map(x=>`- Never use: ${x}`),'','TARGETED FINDINGS:',...findings.map(f=>`- Sentence ${f.sentence} [${f.engine}/${f.id}]: ${f.reason} Repair: ${f.suggestion}`),'','Return only replacement sentences keyed by sentence number. Do not rewrite clean sentences.','',draft].join('\n'); }
-function preservation(original:string,candidate:string){ const a=new Set(words(original.toLowerCase()).filter(w=>w.length>4)), b=new Set(words(candidate.toLowerCase())); return a.size?Math.round([...a].filter(w=>b.has(w)).length/a.size*100):100; }
-export function verify(original:string,candidate:string,profile:Profile):Verification { const baseline=analyze(original,profile), checked=analyze(candidate,profile); const known=new Set([...baseline.voiceDna.findings,...baseline.aiEditor.findings].map(f=>`${f.engine}:${f.id}:${f.sentence}`)); const regressions=[...checked.voiceDna.findings,...checked.aiEditor.findings].filter(f=>!known.has(`${f.engine}:${f.id}:${f.sentence}`)); const preservationScore=preservation(original,candidate); return {...checked,preservationScore,regressions,passed:checked.passed&&regressions.filter(f=>f.severity==='red').length===0&&preservationScore>=70}; }
+import type { Analysis, Finding, Profile, Verification } from './contracts.js';
+import { analyzeAiEditor } from './ai-editor.js';
+import { analyzeVoiceDna } from './voice-dna.js';
+import { words } from './text.js';
+
+export function analyze(text: string, profile: Profile): Analysis {
+  const voiceDna = analyzeVoiceDna(text, profile);
+  const aiEditor = analyzeAiEditor(text);
+  return { version: '2', voiceDna, aiEditor, passed: voiceDna.passed && aiEditor.passed };
+}
+
+function formatFindings(findings: Finding[]): string[] {
+  return findings.map((finding) => `- Sentence ${finding.sentence} [${finding.engine}/${finding.id}]: ${finding.reason} Repair: ${finding.suggestion}`);
+}
+
+export function rewritePrompt(draft: string, profile: Profile): string {
+  const result = analyze(draft, profile);
+  const allFindings = [...result.voiceDna.findings, ...result.aiEditor.findings];
+  const redFindings = allFindings.filter((finding) => finding.severity === 'red');
+  const yellowFindings = allFindings.filter((finding) => finding.severity === 'yellow');
+  const metrics = profile.metrics;
+
+  return [
+    '# Tier 0 — non-negotiable preservation',
+    'Preserve facts, names, numbers, claims, and every unflagged sentence exactly. Do not add claims, examples, sections, hooks, or CTAs.',
+    '',
+    '# Tier 1 — release blockers',
+    `VoiceDNA: ${result.voiceDna.score}/100 (${result.voiceDna.passed ? 'pass' : 'fail'}).`,
+    `AI Editor: ${result.aiEditor.score}/100 (${result.aiEditor.passed ? 'pass' : 'fail'}).`,
+    ...profile.avoid.map((phrase) => `- Never use: ${phrase}`),
+    ...(redFindings.length ? formatFindings(redFindings) : ['- None.']),
+    '',
+    '# Tier 2 — VoiceDNA fidelity',
+    `- Sentence length: ${metrics.sentenceLength}; variation: ${metrics.sentenceVariation}; rhythm: ${metrics.rhythm}.`,
+    `- Paragraph length: ${metrics.paragraphLength}; casing: ${metrics.caseStyle}; point of view: ${metrics.pointOfView}.`,
+    `- Openings: ${metrics.openingMoves.join(', ') || 'none recorded'}.`,
+    `- Vocabulary: ${metrics.vocabulary.join(', ') || 'none recorded'}.`,
+    `- Transitions: ${metrics.transitions.join(', ') || 'none recorded'}.`,
+    '',
+    '# Tier 3 — AI Editor improvements',
+    ...(yellowFindings.length ? formatFindings(yellowFindings) : ['- None.']),
+    '',
+    '# Tier 4 — output contract',
+    'Return only replacement sentences keyed by sentence number. Do not rewrite clean sentences. The candidate will be checked again by both engines.',
+    '',
+    '# Draft',
+    draft,
+  ].join('\n');
+}
+
+function preservationScore(original: string, candidate: string): number {
+  const baseline = new Set(words(original.toLowerCase()).filter((word) => word.length > 4));
+  const rewritten = new Set(words(candidate.toLowerCase()));
+  return baseline.size ? Math.round([...baseline].filter((word) => rewritten.has(word)).length / baseline.size * 100) : 100;
+}
+
+export function verify(original: string, candidate: string, profile: Profile): Verification {
+  const baseline = analyze(original, profile);
+  const checked = analyze(candidate, profile);
+  const known = new Set([...baseline.voiceDna.findings, ...baseline.aiEditor.findings].map((finding) => `${finding.engine}:${finding.id}:${finding.sentence}`));
+  const regressions = [...checked.voiceDna.findings, ...checked.aiEditor.findings].filter((finding) => !known.has(`${finding.engine}:${finding.id}:${finding.sentence}`));
+  const preservation = preservationScore(original, candidate);
+  return { ...checked, preservationScore: preservation, regressions, passed: checked.passed && !regressions.some((finding) => finding.severity === 'red') && preservation >= 70 };
+}

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,5 +1,26 @@
 import type { Sentence } from './contracts.js';
-export const words = (text: string) => text.match(/[A-Za-z][A-Za-z'-]*/g) ?? [];
-export function sentences(text: string): Sentence[] { const rx = /[^.!?\n]+[.!?]+|[^\n]+$/g; const out: Sentence[] = []; for (const m of text.matchAll(rx)) { const value=m[0].trim(); if (words(value).length) { const leading=m[0].indexOf(value); out.push({index:out.length+1,start:(m.index??0)+leading,end:(m.index??0)+leading+value.length,text:value}); } } return out; }
-export const mean = (xs:number[]) => xs.length ? xs.reduce((a,b)=>a+b,0)/xs.length : 0;
-export const deviation = (xs:number[], avg=mean(xs)) => xs.length ? Math.sqrt(mean(xs.map(x=>(x-avg)**2))) : 0;
+
+export const words = (text: string): string[] =>
+  text.match(/[A-Za-z][A-Za-z'-]*/g) ?? [];
+
+export const mean = (values: number[]): number =>
+  values.length ? values.reduce((total, value) => total + value, 0) / values.length : 0;
+
+export const deviation = (values: number[], average = mean(values)): number =>
+  values.length ? Math.sqrt(mean(values.map((value) => (value - average) ** 2))) : 0;
+
+export function sentences(text: string): Sentence[] {
+  const matches = text.matchAll(/[^.!?\n]+[.!?]+|[^\n]+$/g);
+  const output: Sentence[] = [];
+
+  for (const match of matches) {
+    const value = match[0].trim();
+    if (!words(value).length) continue;
+    const start = (match.index ?? 0) + match[0].indexOf(value);
+    output.push({ index: output.length + 1, start, end: start + value.length, text: value });
+  }
+  return output;
+}
+
+export const paragraphs = (text: string): string[] =>
+  text.split(/\n\s*\n/).map((part) => part.trim()).filter(Boolean);

--- a/src/voice-dna.ts
+++ b/src/voice-dna.ts
@@ -1,5 +1,77 @@
-import type { EngineReport, Finding, Profile } from './contracts.js'; import { deviation, mean, sentences, words } from './text.js';
-const stop=new Set(['the','and','that','with','this','from','your','have','were','they','will','into','about','what','when','where']);
-export function buildProfile(samples:string[], avoid:string[]=[]):Profile { if(samples.length<2) throw new Error('Provide at least two local writing samples.'); const ss=sentences(samples.join('\n')); const lengths=ss.map(s=>words(s.text).length); const counts=new Map<string,number>(); for(const w of words(samples.join(' ').toLowerCase())) if(w.length>3&&!stop.has(w)) counts.set(w,(counts.get(w)??0)+1); return {version:'1',sampleCount:samples.length,averageSentenceWords:Number(mean(lengths).toFixed(2)),sentenceDeviation:Number(deviation(lengths).toFixed(2)),commonOpeners:ss.map(s=>words(s.text)[0]?.toLowerCase()).filter(Boolean).slice(0,12) as string[],preferredWords:[...counts].sort((a,b)=>b[1]-a[1]).slice(0,20).map(x=>x[0]),avoid}; }
-export function analyzeVoiceDna(text:string, profile:Profile):EngineReport { const findings:Finding[]=[]; for(const s of sentences(text)){ const count=words(s.text).length; const delta=Math.abs(count-profile.averageSentenceWords); if(delta>Math.max(8,profile.sentenceDeviation*2.2)) findings.push({engine:'voice_dna',id:'dna.cadence-drift',severity:'yellow',sentence:s.index,excerpt:s.text,reason:`${count} words differs from the profile average of ${profile.averageSentenceWords}.`,suggestion:'Match the established sentence rhythm without forcing it.'}); for(const banned of profile.avoid) if(s.text.toLowerCase().includes(banned.toLowerCase())) findings.push({engine:'voice_dna',id:'dna.avoid-list',severity:'red',sentence:s.index,excerpt:s.text,reason:`Uses profile avoid-list phrase: ${banned}.`,suggestion:'Replace it with the writer’s natural language.'}); }
-const reds=findings.filter(f=>f.severity==='red').length, yellows=findings.length-reds, score=Math.max(0,100-reds*25-yellows*7); return {engine:'voice_dna',version:'1',score,passed:score>=75,findings}; }
+import type { EngineReport, Finding, Profile, VoiceDnaMetrics } from './contracts.js';
+import { deviation, mean, paragraphs, sentences, words } from './text.js';
+
+const STOP_WORDS = new Set(['the', 'and', 'that', 'with', 'this', 'from', 'your', 'have', 'were', 'they', 'will', 'into', 'about', 'what', 'when', 'where']);
+const TRANSITIONS = ['but', 'because', 'instead', 'then', 'still', 'so', 'yet', 'therefore'];
+
+function top(items: string[], limit: number): string[] {
+  const counts = new Map<string, number>();
+  for (const item of items.filter(Boolean)) counts.set(item, (counts.get(item) ?? 0) + 1);
+  return [...counts].sort((left, right) => right[1] - left[1]).slice(0, limit).map(([item]) => item);
+}
+
+function profileMetrics(text: string): VoiceDnaMetrics {
+  const draftSentences = sentences(text);
+  const draftWords = words(text);
+  const lengths = draftSentences.map((sentence) => words(sentence.text).length);
+  const starters = draftSentences.map((sentence) => words(sentence.text)[0]?.toLowerCase() ?? '');
+  const structures = draftSentences.map((sentence) => words(sentence.text).slice(0, 3).map((word) => word.toLowerCase()).join(' '));
+  const lowerWords = draftWords.map((word) => word.toLowerCase());
+  const nonStop = lowerWords.filter((word) => word.length > 3 && !STOP_WORDS.has(word));
+  const first = lowerWords.filter((word) => ['i', 'we', 'my', 'our', 'us'].includes(word)).length;
+  const second = lowerWords.filter((word) => ['you', 'your', 'yours'].includes(word)).length;
+  const third = lowerWords.filter((word) => ['he', 'she', 'they', 'their', 'them'].includes(word)).length;
+  const pov = first > second && first > third ? 'first_person' : second > first && second > third ? 'second_person' : third > first && third > second ? 'third_person' : 'mixed';
+  const paragraphSizes = paragraphs(text).map((paragraph) => sentences(paragraph).length);
+  const punctuation = Object.fromEntries(['!', '?', ';', ':', '—'].map((mark) => [mark, (text.match(new RegExp(mark.replace(/[?*+^$.[\]\\(){}|-]/g, '\\$&'), 'g')) ?? []).length]));
+  const sentenceLength = mean(lengths);
+  const sentenceVariation = deviation(lengths, sentenceLength);
+  const rhythm = lengths.length > 1 ? mean(lengths.slice(1).map((length, index) => Math.abs(length - lengths[index]))) : 0;
+  const uppercaseStarts = draftSentences.filter((sentence) => /^[A-Z]/.test(sentence.text)).length;
+  const caseStyle = uppercaseStarts / Math.max(1, draftSentences.length) > 0.8 ? 'standard' : uppercaseStarts === 0 ? 'lowercase' : 'mixed';
+
+  return {
+    sentenceLength: Number(sentenceLength.toFixed(2)),
+    sentenceVariation: Number(sentenceVariation.toFixed(2)),
+    sentenceStructure: top(structures, 8),
+    rhythm: Number(rhythm.toFixed(2)),
+    paragraphLength: Number(mean(paragraphSizes).toFixed(2)),
+    openingMoves: top(starters, 8),
+    vocabulary: top(nonStop, 20),
+    lexicalDensity: Number((nonStop.length / Math.max(1, lowerWords.length)).toFixed(3)),
+    pointOfView: pov,
+    punctuation,
+    caseStyle,
+    questionRate: Number((draftSentences.filter((sentence) => sentence.text.endsWith('?')).length / Math.max(1, draftSentences.length)).toFixed(3)),
+    transitions: top(lowerWords.filter((word) => TRANSITIONS.includes(word)), 8),
+  };
+}
+
+export function buildProfile(samples: string[], avoid: string[] = []): Profile {
+  if (samples.length < 2) throw new Error('Provide at least two local writing samples.');
+  return { version: '2', sampleCount: samples.length, metrics: profileMetrics(samples.join('\n\n')), avoid };
+}
+
+function finding(id: string, severity: Finding['severity'], sentence: number, excerpt: string, reason: string, suggestion: string): Finding {
+  return { engine: 'voice_dna', id, severity, sentence, excerpt, reason, suggestion };
+}
+
+export function analyzeVoiceDna(text: string, profile: Profile): EngineReport {
+  const metrics = profileMetrics(text);
+  const findings: Finding[] = [];
+  const tolerance = Math.max(8, profile.metrics.sentenceVariation * 2.2);
+
+  for (const sentence of sentences(text)) {
+    const count = words(sentence.text).length;
+    if (Math.abs(count - profile.metrics.sentenceLength) > tolerance) findings.push(finding('dna.sentence-length', 'yellow', sentence.index, sentence.text, `Sentence length (${count}) is outside the profile band around ${profile.metrics.sentenceLength}.`, 'Restore the writer’s usual sentence length where it improves clarity.'));
+    for (const banned of profile.avoid) if (sentence.text.toLowerCase().includes(banned.toLowerCase())) findings.push(finding('dna.avoid-list', 'red', sentence.index, sentence.text, `Uses profile avoid-list phrase: ${banned}.`, 'Replace it with the writer’s natural language.'));
+  }
+  if (Math.abs(metrics.questionRate - profile.metrics.questionRate) > 0.25) findings.push(finding('dna.question-rate', 'yellow', 1, text.slice(0, 160), 'Question frequency differs materially from the profile.', 'Match the writer’s usual use of questions.'));
+  if (metrics.caseStyle !== profile.metrics.caseStyle) findings.push(finding('dna.case-style', 'yellow', 1, text.slice(0, 160), `Draft uses ${metrics.caseStyle} casing; profile uses ${profile.metrics.caseStyle}.`, 'Use the profile’s normal casing.'));
+  if (metrics.pointOfView !== profile.metrics.pointOfView && profile.metrics.pointOfView !== 'mixed') findings.push(finding('dna.point-of-view', 'yellow', 1, text.slice(0, 160), `Draft point of view is ${metrics.pointOfView}; profile is ${profile.metrics.pointOfView}.`, 'Restore the writer’s normal narrative distance.'));
+
+  const red = findings.filter((item) => item.severity === 'red').length;
+  const yellow = findings.length - red;
+  const score = Math.max(0, 100 - red * 25 - yellow * 7);
+  return { engine: 'voice_dna', version: '2', score, passed: score >= 75, findings };
+}


### PR DESCRIPTION
## Changes\n- Adds a five-tier prompt contract: preservation, blockers, VoiceDNA, AI Editor, and output.\n- Builds a transparent 13-element VoiceDNA profile and keeps engine scores separate.\n- Adds GitHub Sponsors funding plus a no-paywall support policy.\n- Rewrites README and architecture docs for contributor clarity.\n\n## Verified\n- npm test\n- npm run check:release