### PR TITLE
fix: add direct sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: shashank-sn
+custom: ['https://github.com/sponsors/shashank-sn']


### PR DESCRIPTION
Adds the public GitHub Sponsors URL as a custom funding link alongside the native Sponsors handle so GitHub has an explicit repository Sponsor destination.