### PR TITLE
fix: close local CLI quality gaps

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
 github: shashank-sn
-custom: ['https://github.com/sponsors/shashank-sn']

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This order protects meaning before style. Read the complete [prompt contract](do
 
 ## VoiceDNA: 13 observable elements
 
-VoiceDNA is a local profile of writing mechanics drawn from the samples you choose. It makes no claim about personality.
+VoiceDNA is a local profile of writing mechanics drawn from the samples you choose. It makes no claim about personality. Its structural measurements support Unicode writing; the current point-of-view and transition lists are English-specific evidence.
 
 | # | Element | What it captures | Current gate behavior |
 | --- | --- | --- | --- |

--- a/docs/VOICE-DNA.md
+++ b/docs/VOICE-DNA.md
@@ -1,6 +1,6 @@
 # VoiceDNA
 
-VoiceDNA is a local, inspectable reference built from at least two author-owned samples. It describes repeatable mechanics that an editor can compare with a draft. It makes no identity or authorship claim and uploads nothing.
+VoiceDNA is a local, inspectable reference built from at least two non-empty author-owned samples. It describes repeatable mechanics that an editor can compare with a draft. It makes no identity or authorship claim and uploads nothing. Structural metrics accept Unicode writing; the current point-of-view and transition lists remain English-specific evidence.
 
 ## The 13 elements
 

--- a/docs/wiki/VoiceDNA.md
+++ b/docs/wiki/VoiceDNA.md
@@ -1,6 +1,6 @@
 # voicedna
 
-a profile uses at least two local samples and contains exactly 13 elements: sentence length, sentence variation, sentence structure, rhythm, paragraph length, opening moves, vocabulary, lexical density, point of view, punctuation, case style, question rate, and transitions.
+a profile uses at least two non-empty local samples and contains exactly 13 elements: sentence length, sentence variation, sentence structure, rhythm, paragraph length, opening moves, vocabulary, lexical density, point of view, punctuation, case style, question rate, and transitions. structural metrics accept Unicode writing; the current point-of-view and transition lists are English-specific evidence.
 
 every element is calculated and included in the JSON profile. the automated checks are intentionally narrower: sentence length, explicit avoid-list phrases, question rate, case style, and point of view. avoid-list matches are red. the other active checks are yellow review cues.
 

--- a/src/ai-editor.test.ts
+++ b/src/ai-editor.test.ts
@@ -11,15 +11,53 @@ test('publishes executable rules with stable IDs and repair directions', () => {
   }
 });
 
-test('flags an executable pattern against its exact sentence', () => {
-  const report = analyzeAiEditor('we will delve into it. the work is concrete.');
-  assert.deepEqual(report.findings.map((finding) => [finding.id, finding.severity, finding.sentence]), [['ai.delve', 'red', 1]]);
-  assert.equal(report.passed, false);
+test('detects every executable rule against its exact sentence', () => {
+  const examples = [
+    ['ai.delve', 'we will delve into it.'],
+    ['ai.leverage', 'we leverage the existing logs.'],
+    ['ai.tapestry', 'the tapestry explains the work.'],
+    ['ai.holistic', 'a holistic review starts today.'],
+    ['ai.robust', 'robust evidence supports the claim.'],
+    ['ai.landscape', 'the market landscape changed.'],
+    ['ai.game-changer', 'this is a game-changer.'],
+    ['ai.formulaic-connector', 'Firstly, check the invoice.'],
+    ['ai.hedging', 'Perhaps the invoice is late.'],
+    ['ai.signpost', 'This is why the invoice matters.'],
+    ['ai.not-just', 'this is not just fast but reliable.'],
+    ['ai.truth-setup', 'the hard truth is in the logs.'],
+    ['ai.em-dash', 'the logs failed — retry later.'],
+    ['ai.question-hook', 'Have you checked the logs?'],
+    ['ai.abstract-cluster', 'alignment and clarity are missing.'],
+  ] as const;
+
+  for (const [id, example] of examples) {
+    const report = analyzeAiEditor(example);
+    assert.deepEqual(report.findings.map((finding) => [finding.id, finding.sentence]), [[id, 1]], id);
+  }
 });
 
-test('does not treat an ordinary concrete sentence as an abstract cluster', () => {
-  const report = analyzeAiEditor('the editor checked the contract and sent the invoice.');
-  assert.equal(report.findings.some((finding) => finding.id === 'ai.abstract-cluster'), false);
+test('keeps a counterexample for every executable rule', () => {
+  const counterexamples = [
+    ['ai.delve', 'we inspect the logs.'],
+    ['ai.leverage', 'we use the existing logs.'],
+    ['ai.tapestry', 'the report explains the work.'],
+    ['ai.holistic', 'the review covers the named files.'],
+    ['ai.robust', 'the evidence includes three dated reports.'],
+    ['ai.landscape', 'the market changed after the price cut.'],
+    ['ai.game-changer', 'the release removed a manual step.'],
+    ['ai.formulaic-connector', 'next, check the invoice.'],
+    ['ai.hedging', 'the invoice is late.'],
+    ['ai.signpost', 'the invoice matters because it is overdue.'],
+    ['ai.not-just', 'the service is fast and reliable.'],
+    ['ai.truth-setup', 'the logs show the service failed.'],
+    ['ai.em-dash', 'the logs failed; retry later.'],
+    ['ai.question-hook', 'the reviewer asked, have you checked the logs?'],
+    ['ai.abstract-cluster', 'the editor checked the contract and sent the invoice.'],
+  ] as const;
+
+  for (const [id, example] of counterexamples) {
+    assert.equal(analyzeAiEditor(example).findings.some((finding) => finding.id === id), false, id);
+  }
 });
 
 test('keeps yellow findings as review cues rather than release blockers', () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -99,3 +99,24 @@ test('rejects malformed profile enum values and punctuation', () => {
     rmSync(directory, { recursive: true, force: true });
   }
 });
+
+test('rejects hand-edited metrics outside their semantic bounds', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'holdyourvoice-cli-'));
+  try {
+    const first = join(directory, 'first.md');
+    const second = join(directory, 'second.md');
+    const profile = join(directory, 'profile.json');
+    const draft = join(directory, 'draft.md');
+    writeFileSync(first, 'i write plainly.');
+    writeFileSync(second, 'i name the work.');
+    writeFileSync(draft, 'i name the work.');
+    assert.equal(run('profile', profile, first, second).status, 0);
+    const malformed = JSON.parse(readFileSync(profile, 'utf8'));
+    malformed.sampleCount = 2.5;
+    malformed.metrics.questionRate = 1.2;
+    writeFileSync(profile, JSON.stringify(malformed));
+    assert.equal(run('analyze', draft, profile).status, 1);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ function isNumberRecord(value: unknown): value is Record<string, number> {
 
 function isPunctuation(value: unknown): value is Record<string, number> {
   const marks = ['!', '?', ';', ':', '—'];
-  return isNumberRecord(value) && Object.keys(value).length === marks.length && marks.every((mark) => mark in value);
+  return isNumberRecord(value) && Object.values(value).every((item) => item >= 0) && Object.keys(value).length === marks.length && marks.every((mark) => mark in value);
 }
 
 function isMetrics(value: unknown): value is VoiceDnaMetrics {
@@ -26,7 +26,9 @@ function isMetrics(value: unknown): value is VoiceDnaMetrics {
   const metrics = value as Partial<VoiceDnaMetrics>;
   const numbers = [metrics.sentenceLength, metrics.sentenceVariation, metrics.rhythm, metrics.paragraphLength, metrics.lexicalDensity, metrics.questionRate];
   const stringArrays = [metrics.sentenceStructure, metrics.openingMoves, metrics.vocabulary, metrics.transitions];
-  return numbers.every((item) => typeof item === 'number' && Number.isFinite(item))
+  return numbers.every((item) => typeof item === 'number' && Number.isFinite(item) && item >= 0)
+    && typeof metrics.lexicalDensity === 'number' && metrics.lexicalDensity <= 1
+    && typeof metrics.questionRate === 'number' && metrics.questionRate <= 1
     && ['first_person', 'second_person', 'third_person', 'mixed'].includes(metrics.pointOfView ?? '')
     && ['lowercase', 'standard', 'mixed'].includes(metrics.caseStyle ?? '')
     && stringArrays.every((items) => Array.isArray(items) && items.every((item) => typeof item === 'string'))
@@ -37,7 +39,7 @@ function readProfile(path: string): Profile {
   const value: unknown = JSON.parse(input(path));
   if (!value || typeof value !== 'object') throw new Error('Profile must be a JSON object.');
   const profile = value as Partial<Profile>;
-  if (profile.version !== '2' || typeof profile.sampleCount !== 'number' || profile.sampleCount < 2 || !isMetrics(profile.metrics) || !Array.isArray(profile.avoid) || !profile.avoid.every((item) => typeof item === 'string' && item.trim().length > 0)) {
+  if (profile.version !== '2' || typeof profile.sampleCount !== 'number' || !Number.isInteger(profile.sampleCount) || profile.sampleCount < 2 || !isMetrics(profile.metrics) || !Array.isArray(profile.avoid) || !profile.avoid.every((item) => typeof item === 'string' && item.trim().length > 0)) {
     throw new Error('Profile is not a valid Hold Your Voice version 2 profile. Rebuild it with the profile command.');
   }
   return profile as Profile;

--- a/src/text.test.ts
+++ b/src/text.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { sentences, words } from './text.js';
+
+test('keeps decimals and common abbreviations inside a sentence', () => {
+  assert.deepEqual(
+    sentences('Dr. Shah raised $3.5m. It funded the work.').map((sentence) => sentence.text),
+    ['Dr. Shah raised $3.5m.', 'It funded the work.'],
+  );
+});
+
+test('records exact sentence offsets across newlines', () => {
+  const text = 'First line\nSecond line.';
+  assert.deepEqual(sentences(text), [
+    { index: 1, start: 0, end: 10, text: 'First line' },
+    { index: 2, start: 11, end: 23, text: 'Second line.' },
+  ]);
+});
+
+test('counts Unicode writing as words', () => {
+  assert.deepEqual(words('café नमस्ते दुनिया'), ['café', 'नमस्ते', 'दुनिया']);
+});

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,7 +1,7 @@
 import type { Sentence } from './contracts.js';
 
 export const words = (text: string): string[] =>
-  text.match(/[A-Za-z][A-Za-z'-]*/g) ?? [];
+  text.match(/\p{L}[\p{L}\p{M}'’-]*/gu) ?? [];
 
 export const mean = (values: number[]): number =>
   values.length ? values.reduce((total, value) => total + value, 0) / values.length : 0;
@@ -10,15 +10,39 @@ export const deviation = (values: number[], average = mean(values)): number =>
   values.length ? Math.sqrt(mean(values.map((value) => (value - average) ** 2))) : 0;
 
 export function sentences(text: string): Sentence[] {
-  const matches = text.matchAll(/[^.!?\n]+[.!?]+|[^\n]+$/g);
   const output: Sentence[] = [];
+  const abbreviations = new Set(['dr', 'mr', 'mrs', 'ms', 'prof', 'sr', 'jr', 'vs', 'etc', 'fig', 'no', 'inc', 'ltd', 'co', 'jan', 'feb', 'mar', 'apr', 'jun', 'jul', 'aug', 'sep', 'sept', 'oct', 'nov', 'dec']);
+  let start = 0;
 
-  for (const match of matches) {
-    const value = match[0].trim();
-    if (!words(value).length) continue;
-    const start = (match.index ?? 0) + match[0].indexOf(value);
-    output.push({ index: output.length + 1, start, end: start + value.length, text: value });
+  const add = (end: number): void => {
+    const raw = text.slice(start, end);
+    const value = raw.trim();
+    if (!words(value).length) return;
+    const offset = start + raw.indexOf(value);
+    output.push({ index: output.length + 1, start: offset, end: offset + value.length, text: value });
+  };
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (character === '\n') {
+      add(index);
+      start = index + 1;
+      continue;
+    }
+    if (!'.!?'.includes(character)) continue;
+    if (character === '.') {
+      const previous = text[index - 1] ?? '';
+      const next = text[index + 1] ?? '';
+      const previousWord = text.slice(start, index).match(/(\p{L}+)$/u)?.[1]?.toLowerCase();
+      if ((/\d/.test(previous) && /\d/.test(next)) || /\p{L}/u.test(next) || (previousWord && abbreviations.has(previousWord))) continue;
+    }
+    let end = index + 1;
+    while (end < text.length && '.!?'.includes(text[end])) end += 1;
+    add(end);
+    start = end;
+    index = end - 1;
   }
+  add(text.length);
   return output;
 }
 

--- a/src/voice-dna.test.ts
+++ b/src/voice-dna.test.ts
@@ -6,6 +6,10 @@ test('requires two local samples before creating a profile', () => {
   assert.throws(() => buildProfile(['One sample is not enough.']), /at least two local writing samples/);
 });
 
+test('requires every local sample to contain writing', () => {
+  assert.throws(() => buildProfile(['', '   ']), /must contain writing/);
+});
+
 test('reports local avoid-list matches as red sentence findings', () => {
   const profile = buildProfile(['i write plainly. i name the work.', 'i keep the mechanism clear. i avoid filler.'], ['unlock']);
   const report = analyzeVoiceDna('i unlock the answer. i name the work.', profile);
@@ -17,5 +21,17 @@ test('keeps a case-style mismatch as a yellow review cue', () => {
   const profile = buildProfile(['i write plainly. i name the work.', 'i keep the mechanism clear. i avoid filler.']);
   const report = analyzeVoiceDna('This sentence starts in standard case.', profile);
   assert.ok(report.findings.some((finding) => finding.id === 'dna.case-style' && finding.severity === 'yellow'));
+  assert.equal(report.passed, true);
+});
+
+test('keeps the documented VoiceDNA review checks as yellow findings', () => {
+  const profile = buildProfile([
+    'i write short sentences. i ask no questions. i name the mechanism.',
+    'i keep the language plain. i explain the work. i use first person.',
+  ]);
+  const report = analyzeVoiceDna('You explain a much longer sentence with several extra words so the reader can follow the full mechanism in detail. Do you agree?', profile);
+  for (const id of ['dna.sentence-length', 'dna.question-rate', 'dna.point-of-view']) {
+    assert.ok(report.findings.some((finding) => finding.id === id && finding.severity === 'yellow'), id);
+  }
   assert.equal(report.passed, true);
 });

--- a/src/voice-dna.ts
+++ b/src/voice-dna.ts
@@ -27,7 +27,7 @@ function profileMetrics(text: string): VoiceDnaMetrics {
   const sentenceLength = mean(lengths);
   const sentenceVariation = deviation(lengths, sentenceLength);
   const rhythm = lengths.length > 1 ? mean(lengths.slice(1).map((length, index) => Math.abs(length - lengths[index]))) : 0;
-  const uppercaseStarts = draftSentences.filter((sentence) => /^[A-Z]/.test(sentence.text)).length;
+  const uppercaseStarts = draftSentences.filter((sentence) => /^\p{Lu}/u.test(sentence.text)).length;
   const caseStyle = uppercaseStarts / Math.max(1, draftSentences.length) > 0.8 ? 'standard' : uppercaseStarts === 0 ? 'lowercase' : 'mixed';
 
   return {
@@ -49,6 +49,7 @@ function profileMetrics(text: string): VoiceDnaMetrics {
 
 export function buildProfile(samples: string[], avoid: string[] = []): Profile {
   if (samples.length < 2) throw new Error('Provide at least two local writing samples.');
+  if (samples.some((sample) => !words(sample).length)) throw new Error('Every local writing sample must contain writing.');
   return { version: '2', sampleCount: samples.length, metrics: profileMetrics(samples.join('\n\n')), avoid };
 }
 


### PR DESCRIPTION
## Summary

The local CLI now rejects empty samples and semantically invalid profiles, keeps sentence findings aligned around decimals and common abbreviations, and measures Unicode words. Every executable AI Editor rule now has both a detecting example and a counterexample. Repository funding now exposes one canonical GitHub Sponsors link.

## Validation

- `npm test` — 23 passing tests
- `npm run check:release`
- `git diff --check`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a local CLI and repository-metadata change with no deployed runtime.