### PR TITLE
docs: add funding policy

### DIFF
--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,0 +1,17 @@
+# Funding Hold Your Voice
+
+Hold Your Voice is MIT-licensed and fully usable without payment.
+
+## Sponsor maintenance
+
+[Sponsor Hold Your Voice on GitHub](https://github.com/sponsors/shashank-sn) with a one-time or recurring sponsorship.
+
+Sponsorship helps fund maintenance, deterministic-rule research, tests, documentation, reproducible evaluations, accessibility work, and local-first privacy review.
+
+## What sponsorship does not change
+
+Sponsorship never grants private source access, product features, donor-data collection, editorial influence, custom development, priority feature requests, or priority support. The same source, privacy boundary, and contribution process apply to everyone.
+
+## Other useful support
+
+Open a reproducible bug report, propose a tested rule with a counterexample, improve documentation, or contribute a synthetic or author-owned evaluation fixture.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Keep chan
 
 ## Support
 
-Hold Your Voice stays fully open source. [Sponsor maintenance on GitHub](https://github.com/sponsors/shashank-sn) with a one-time or recurring sponsorship. Sponsorship funds maintenance while the feature set and local privacy contract remain the same for everyone.
+Hold Your Voice stays fully open source. Read the [funding policy](FUNDING.md) or [sponsor maintenance on GitHub](https://github.com/sponsors/shashank-sn) with a one-time or recurring sponsorship. Sponsorship funds maintenance while the feature set and local privacy contract remain the same for everyone.
 
 ## License
 


### PR DESCRIPTION
## Summary

The repository now has a standalone funding policy linked from the README. It makes the Sponsor button’s purpose clear while documenting that sponsorship cannot buy product, editorial, support, or source-code privileges.

GitHub surfaces funding through the native Sponsor button; it does not create a README-style Funding tab for `FUNDING.md`.

## Validation

- `npm test` — 23 passing tests
- `npm run check:release`
- `git diff --check`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: documentation-only change with no runtime effect.