### PR TITLE
feat: publish open-source hyv CLI to npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,60 @@
+name: Publish npm package
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - package.json
+      - package-lock.json
+      - src/**
+      - Readme.md
+      - LICENSE
+      - .github/workflows/npm-publish.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm test
+      - run: npm run check:release
+      - name: Check whether this version is already published
+        id: version
+        run: |
+          version=$(node -p "require('./package.json').version")
+          if npm view "@holdyourvoice/hyv@${version}" version 2>/dev/null | grep -qxF "$version"; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish version
+        if: steps.version.outputs.publish == 'true'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Verify registry package
+        run: |
+          version=$(node -p "require('./package.json').version")
+          for attempt in 1 2 3 4 5 6; do
+            if npm view "@holdyourvoice/hyv@${version}" version 2>/dev/null | grep -qxF "$version" \
+              && test "$(npm view "@holdyourvoice/hyv@${version}" license)" = "MIT"; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "npm did not expose @holdyourvoice/hyv@${version} with an MIT license"
+          exit 1

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ Those programs keep separate findings, scores, and pass states. A strong result 
 
 Everything runs from local files: accounts, API calls, MCP servers, telemetry, payment collection, and runtime network requests stay out of the core path.
 
-> **Status:** this public source repository ships as a local development CLI. Build it locally and run `node dist/cli.js`; npm publication comes later.
+> **Status:** the public CLI is published as [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv). It runs locally and makes no runtime network requests.
 
 ## Why it exists
 
@@ -38,22 +38,22 @@ Its scope is a local writing gate. Authorship detection, fact checking, plagiari
 ### Install and verify
 
 ```bash
-git clone https://github.com/shashank-sn/holdyourvoice.git
-cd holdyourvoice
-npm install
-npm test
+npx @holdyourvoice/hyv patterns
 ```
 
-`npm test` compiles TypeScript and runs the contract tests. Build separately whenever you want to call the CLI directly:
+Run any command without a global install with `npx @holdyourvoice/hyv`. To use the short `hyv` command repeatedly:
 
 ```bash
-npm run build
+npm install --global @holdyourvoice/hyv
+hyv patterns
 ```
+
+To contribute, clone this repository, run `npm install`, then run `npm test` and `npm run check:release`.
 
 ### Build a local VoiceDNA profile
 
 ```bash
-node dist/cli.js profile profile.json samples/one.md samples/two.md --avoid=overused-phrase
+npx @holdyourvoice/hyv profile profile.json samples/one.md samples/two.md --avoid=overused-phrase
 ```
 
 Use writing by one person, with a similar audience and format where possible. The command needs at least two samples. It creates a portable JSON profile and keeps the samples on your machine. Repeat `--avoid=phrase` for each local phrase that must block a candidate.
@@ -61,7 +61,7 @@ Use writing by one person, with a similar audience and format where possible. Th
 ### Inspect a draft
 
 ```bash
-node dist/cli.js analyze draft.md profile.json
+npx @holdyourvoice/hyv analyze draft.md profile.json
 ```
 
 The result is JSON with independent reports:
@@ -79,7 +79,7 @@ Read both reports. The outer `passed` field means each engine passed. Scores rem
 ### Create an editing brief
 
 ```bash
-node dist/cli.js rewrite-prompt draft.md profile.json > rewrite-brief.md
+npx @holdyourvoice/hyv rewrite-prompt draft.md profile.json > rewrite-brief.md
 ```
 
 Give the brief and draft to a human editor or any model you trust. This repository stays out of that provider call. Ask for replacement sentences keyed by sentence number, then save the output as a separate candidate file.
@@ -87,7 +87,7 @@ Give the brief and draft to a human editor or any model you trust. This reposito
 ### Verify the candidate
 
 ```bash
-node dist/cli.js verify draft.md candidate.md profile.json
+npx @holdyourvoice/hyv verify draft.md candidate.md profile.json
 ```
 
 `verify` returns the original and candidate reports, identifies newly introduced findings, calculates a coarse preservation score, and exits with status `2` when the candidate fails the dual gate. It exits with `1` for a usage or runtime error. Treat status `2` as a release signal in scripts or CI.
@@ -154,7 +154,7 @@ Read the full [VoiceDNA reference](docs/VOICE-DNA.md) and [Wiki guide](https://g
 AI Editor uses a local, deterministic ruleset. Each rule has a stable ID, severity, reason, and repair direction. Run this command to see the rules that actually execute in your checkout:
 
 ```bash
-node dist/cli.js patterns
+npx @holdyourvoice/hyv patterns
 ```
 
 Red findings are release blockers. Yellow findings are a request to inspect a sentence in context. A match never proves who wrote the text, and a clean scan never proves the text is good.
@@ -176,13 +176,13 @@ The preservation score is a guardrail based on retained original words longer th
 
 | Command | Input | Output | Use it when |
 | --- | --- | --- | --- |
-| `profile <profile.json> <sample...>` | Two or more text files | Profile JSON | You need a new local reference. |
-| `analyze <draft> <profile.json>` | Draft and profile | Analysis JSON | You need both reports before editing. |
-| `rewrite-prompt <draft> <profile.json>` | Draft and profile | Markdown editing brief | You need a constrained request for an editor or model. |
-| `verify <original> <candidate> <profile.json>` | Original, candidate, profile | Verification JSON and exit code | You need the candidate gate. |
-| `patterns` | None | Ruleset JSON | You need the exact enabled rules. |
+| `hyv profile <profile.json> <sample...>` | Two or more text files | Profile JSON | You need a new local reference. |
+| `hyv analyze <draft> <profile.json>` | Draft and profile | Analysis JSON | You need both reports before editing. |
+| `hyv rewrite-prompt <draft> <profile.json>` | Draft and profile | Markdown editing brief | You need a constrained request for an editor or model. |
+| `hyv verify <original> <candidate> <profile.json>` | Original, candidate, profile | Verification JSON and exit code | You need the candidate gate. |
+| `hyv patterns` | None | Ruleset JSON | You need the exact enabled rules. |
 
-Every file argument can be `-` when the command accepts text input from standard input. Profile output is always written to the path you give it.
+Every file argument can be `-` when the command accepts text input from standard input. Profile output is always written to the path you give it. Use `npx @holdyourvoice/hyv <command>` in place of `hyv <command>` when you have not installed the CLI globally.
 
 ## Project map
 
@@ -233,6 +233,10 @@ npm run check:release
 ```
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Keep changes narrow. Add tests when code behavior changes. Separate current executable behavior, editorial guidance, historical research, and proposals. Keep private, client, secret, and unlicensed material out of issues, fixtures, tests, and documentation.
+
+## npm releases
+
+`@holdyourvoice/hyv` is published automatically after a change to the package source reaches `main`. The workflow publishes only when the version in `package.json` is not already on npm, so bump that version in the same pull request as a release-worthy change. It runs the tests and release audit before publishing, then verifies that npm reports the package as MIT licensed.
 
 ## Support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "holdyourvoice",
-  "version": "0.1.0",
+  "name": "@holdyourvoice/hyv",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "holdyourvoice",
-      "version": "0.1.0",
+      "name": "@holdyourvoice/hyv",
+      "version": "3.0.0",
       "license": "MIT",
       "bin": {
-        "holdyourvoice": "dist/cli.js"
+        "hyv": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
-  "name": "holdyourvoice",
-  "version": "0.1.0",
-  "private": true,
-  "description": "A local-first dual-engine writing quality gate.",
+  "name": "@holdyourvoice/hyv",
+  "version": "3.0.0",
+  "description": "A local-first dual-engine writing gate that protects voice and catches generic AI patterns.",
   "type": "module",
-  "bin": { "holdyourvoice": "dist/cli.js" },
-  "scripts": { "build": "tsc -p tsconfig.json", "test": "npm run build && node --test dist/**/*.test.js", "check:release": "node scripts/release-audit.mjs" },
+  "bin": { "hyv": "dist/cli.js" },
+  "files": ["dist", "Readme.md", "LICENSE"],
+  "scripts": { "build": "tsc -p tsconfig.json", "test": "npm run build && node --test dist/**/*.test.js", "check:release": "node scripts/release-audit.mjs", "prepack": "npm run check:release && npm test" },
   "engines": { "node": ">=20" },
   "license": "MIT",
+  "keywords": ["ai-writing", "cli", "editing", "voice", "writing"],
+  "repository": { "type": "git", "url": "git+https://github.com/shashank-sn/holdyourvoice.git" },
+  "bugs": { "url": "https://github.com/shashank-sn/holdyourvoice/issues" },
+  "homepage": "https://github.com/shashank-sn/holdyourvoice#readme",
+  "publishConfig": { "access": "public" },
   "devDependencies": { "@types/node": "^22.0.0", "typescript": "^5.7.0" }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,7 +62,7 @@ function profileArguments(args: string[]): { output: string; samples: string[]; 
       samples.push(argument);
     }
   }
-  if (!output || samples.length < 2) throw new Error('Usage: holdyourvoice profile profile.json sample-a.md sample-b.md [sample-c.md] [--avoid=phrase]');
+  if (!output || samples.length < 2) throw new Error('Usage: hyv profile profile.json sample-a.md sample-b.md [sample-c.md] [--avoid=phrase]');
   return { output, samples, avoid };
 }
 
@@ -75,19 +75,19 @@ export function runCli(args: string[]): number {
   }
   if (command === 'analyze') {
     const [draft, profilePath] = rest;
-    if (!draft || !profilePath) throw new Error('Usage: holdyourvoice analyze draft.md profile.json');
+    if (!draft || !profilePath) throw new Error('Usage: hyv analyze draft.md profile.json');
     json(analyze(input(draft), readProfile(profilePath)));
     return 0;
   }
   if (command === 'rewrite-prompt') {
     const [draft, profilePath] = rest;
-    if (!draft || !profilePath) throw new Error('Usage: holdyourvoice rewrite-prompt draft.md profile.json');
+    if (!draft || !profilePath) throw new Error('Usage: hyv rewrite-prompt draft.md profile.json');
     console.log(rewritePrompt(input(draft), readProfile(profilePath)));
     return 0;
   }
   if (command === 'verify') {
     const [original, candidate, profilePath] = rest;
-    if (!original || !candidate || !profilePath) throw new Error('Usage: holdyourvoice verify original.md candidate.md profile.json');
+    if (!original || !candidate || !profilePath) throw new Error('Usage: hyv verify original.md candidate.md profile.json');
     const result = verify(input(original), input(candidate), readProfile(profilePath));
     json(result);
     return result.passed ? 0 : 2;


### PR DESCRIPTION
## Summary
- publish the MIT local CLI as `@holdyourvoice/hyv` version `3.0.0`
- document `npx` and global `hyv` usage in the repository README
- publish on `main` only after tests and release audit, then verify the npm version and MIT license

## Validation
- `npm test` (23 passed)
- `npm run check:release`
- packed-tarball smoke test: `hyv patterns` (15 rules)

## Post-merge verification
- confirm the Actions publish run completes
- run `npx @holdyourvoice/hyv@3.0.0 patterns`
- confirm `npm view @holdyourvoice/hyv@3.0.0 license` returns `MIT`