### PR TITLE
docs: showcase npm adoption

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,6 @@
 
 [![npm downloads](https://img.shields.io/npm/dt/%40holdyourvoice%2Fhyv?label=npm%20downloads&color=2f81f7)](https://www.npmjs.com/package/@holdyourvoice/hyv)
 
-> **17K+ recorded npm downloads.** `@holdyourvoice/hyv` recorded 17,285 downloads from 31 May through 4 August 2026. [See the live download history.](https://npm-stat.com/charts.html?package=%40holdyourvoice%2Fhyv&from=2025-08-04&to=2026-08-04)
 
 Hold Your Voice is an MIT-licensed, local-first writing gate for people who want AI help without losing the parts of their writing that make it theirs.
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,9 @@
 # Hold Your Voice
 
+[![npm downloads](https://img.shields.io/npm/dt/%40holdyourvoice%2Fhyv?label=npm%20downloads&color=2f81f7)](https://www.npmjs.com/package/@holdyourvoice/hyv)
+
+> **17K+ recorded npm downloads.** `@holdyourvoice/hyv` recorded 17,285 downloads from 31 May through 4 August 2026. [See the live download history.](https://npm-stat.com/charts.html?package=%40holdyourvoice%2Fhyv&from=2025-08-04&to=2026-08-04)
+
 Hold Your Voice is an MIT-licensed, local-first writing gate for people who want AI help without losing the parts of their writing that make it theirs.
 
 It checks a draft through two separate programs:


### PR DESCRIPTION
## What changed

- Adds a live total-download badge for `@holdyourvoice/hyv` at the top of the README.

## Why

Makes public package adoption visible without a dated download claim. The badge updates as npm reports new downloads.

## Validation

- CI passed on the final documentation commit.
- Documentation-only change; no code or package files changed.
