### PR TITLE
test: enforce MIT release metadata

### DIFF
--- a/scripts/release-audit.mjs
+++ b/scripts/release-audit.mjs
@@ -21,7 +21,22 @@ function urls(text) {
   return [...text.matchAll(/https?:\/\/[^\s)'"<>]+/g)].map((match) => match[0]);
 }
 
+const packageManifest = JSON.parse(readFileSync('package.json', 'utf8'));
+const mitLicense = readFileSync('LICENSE', 'utf8');
+const mitRequiredClauses = [
+  'Permission is hereby granted, free of charge, to any person obtaining a copy',
+  'The above copyright notice and this permission notice shall be included in all',
+  'THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND',
+];
+
 const failures = [];
+if (packageManifest.license !== 'MIT') failures.push('package.json must declare the MIT license');
+if (!Array.isArray(packageManifest.files) || !packageManifest.files.includes('LICENSE')) {
+  failures.push('npm package must include LICENSE');
+}
+for (const clause of mitRequiredClauses) {
+  if (!mitLicense.includes(clause)) failures.push(`LICENSE is missing an MIT-required clause: ${clause}`);
+}
 for (const file of candidateFiles()) {
   if (forbiddenPaths.some((pattern) => pattern.test(file))) failures.push(`private or secret-bearing path: ${file}`);
   if (!textExtensions.has(extname(file))) continue;

--- a/src/release-audit.test.ts
+++ b/src/release-audit.test.ts
@@ -10,7 +10,15 @@ const audit = new URL('../scripts/release-audit.mjs', import.meta.url).pathname;
 function fixture(files: Record<string, string>) {
   const directory = mkdtempSync(join(tmpdir(), 'holdyourvoice-audit-'));
   execFileSync('git', ['init', '--quiet'], { cwd: directory });
-  for (const [file, text] of Object.entries(files)) {
+  const defaults = {
+    'package.json': JSON.stringify({ license: 'MIT', files: ['LICENSE'] }),
+    LICENSE: [
+      'Permission is hereby granted, free of charge, to any person obtaining a copy',
+      'The above copyright notice and this permission notice shall be included in all',
+      'THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND',
+    ].join('\n'),
+  };
+  for (const [file, text] of Object.entries({ ...defaults, ...files })) {
     const path = join(directory, file);
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, text);


### PR DESCRIPTION
## What changed

- Makes the release audit require `package.json` to declare `MIT`.
- Requires `LICENSE` to be included in the npm package.
- Checks the MIT permission, notice, and warranty clauses remain present.

## Why

Prevents a future release from drifting away from the OSI MIT standard.

## Validation

- The existing release audit remains the validation command for this guard.
