### PR TITLE
feat: add Claude Code marketplace plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "hold-your-voice",
+  "description": "Local-first writing tools for Claude Code.",
+  "owner": {
+    "name": "Shashank SN"
+  },
+  "plugins": [
+    {
+      "name": "hold-your-voice",
+      "source": "./claude-plugin",
+      "description": "Keep a writer's voice while using Claude.",
+      "version": "3.0.2",
+      "author": {
+        "name": "Shashank SN"
+      }
+    }
+  ]
+}

--- a/Readme.md
+++ b/Readme.md
@@ -57,6 +57,17 @@ To contribute, clone this repository, run `npm install`, then run `npm test` and
 
 Build the fully local Claude Desktop extension with `npm run pack:claude`, then install `dist/hold-your-voice.mcpb` from **Settings → Extensions → Advanced settings → Install Extension**. The extension accepts text and portable profile JSON in the current conversation only. It does not read or write files, make network requests, or retain writing. See the [Claude Desktop guide](docs/CLAUDE-DESKTOP.md).
 
+### Use it in Claude Code
+
+Hold Your Voice is also a free Claude Code plugin. It starts the same local MCP server through the public npm package; drafts, samples, and profiles stay on your machine.
+
+```text
+/plugin marketplace add shashank-sn/holdyourvoice
+/plugin install hold-your-voice@hold-your-voice
+```
+
+It requires Node.js 20 or newer and npm. See the [Claude Code guide](docs/CLAUDE-CODE.md).
+
 ### Build a local VoiceDNA profile
 
 ```bash

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin.json",
+  "name": "hold-your-voice",
+  "displayName": "Hold Your Voice",
+  "version": "3.0.2",
+  "description": "A local-first writing gate that checks VoiceDNA and AI-editor patterns separately.",
+  "author": {
+    "name": "Shashank SN",
+    "url": "https://github.com/shashank-sn"
+  },
+  "homepage": "https://github.com/shashank-sn/holdyourvoice",
+  "repository": "https://github.com/shashank-sn/holdyourvoice",
+  "license": "MIT",
+  "keywords": ["writing", "voice", "editing", "privacy"],
+  "mcpServers": "./.mcp.json"
+}

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hold-your-voice": {
+      "command": "npm",
+      "args": ["exec", "--yes", "--package=@holdyourvoice/hyv@3.0.2", "--", "hyv", "mcp"]
+    }
+  }
+}

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -1,0 +1,24 @@
+# Hold Your Voice for Claude Code
+
+Use the local Hold Your Voice MCP server from Claude Code. It builds portable VoiceDNA profiles, checks a draft with separate VoiceDNA and AI Editor reports, creates a constrained editing brief, and verifies a revised candidate.
+
+## Privacy
+
+The plugin starts the pinned public `@holdyourvoice/hyv` package locally through `npm exec`. It sends no drafts, samples, profiles, or telemetry to a Hold Your Voice service. The one-time package download is performed by npm.
+
+## Install
+
+```text
+/plugin marketplace add shashank-sn/holdyourvoice
+/plugin install hold-your-voice@hold-your-voice
+```
+
+Node.js 20 or later and npm are required. Claude Code starts the MCP server when the plugin is enabled.
+
+## Tools
+
+- `hyv_build_profile`: build a portable profile from at least two supplied writing samples.
+- `hyv_analyze`: run the two independent checks on a draft.
+- `hyv_rewrite_prompt`: make an editing brief without changing the draft.
+- `hyv_verify`: check a candidate for regressions and preservation.
+- `hyv_patterns`: list the exact executable pattern rules.

--- a/docs/CLAUDE-CODE.md
+++ b/docs/CLAUDE-CODE.md
@@ -1,0 +1,26 @@
+# Claude Code plugin
+
+Hold Your Voice ships as a free Claude Code plugin through this public GitHub marketplace. It starts the MIT-licensed npm package locally through `npx`; no Hold Your Voice server receives writing, profiles, or telemetry.
+
+## Install
+
+In Claude Code, run:
+
+```text
+/plugin marketplace add shashank-sn/holdyourvoice
+/plugin install hold-your-voice@hold-your-voice
+```
+
+Node.js 20 or newer and npm must be installed. Claude Code uses `npm exec --package=@holdyourvoice/hyv@3.0.2 -- hyv mcp` to download the pinned public package and start a local stdio process.
+
+## What it exposes
+
+| Tool | Purpose |
+| --- | --- |
+| `hyv_build_profile` | Build a portable VoiceDNA profile from supplied samples. |
+| `hyv_analyze` | Check a draft with separate VoiceDNA and AI Editor reports. |
+| `hyv_rewrite_prompt` | Create a constrained editing brief without rewriting text. |
+| `hyv_verify` | Verify a candidate for new findings and lexical preservation. |
+| `hyv_patterns` | List the exact executable editorial rules. |
+
+The plugin is read-only: it takes writing and profile JSON in the current tool call, does not accept file paths or credentials, and does not write or retain text.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "hold-your-voice",
   "display_name": "Hold Your Voice",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Keep your writing voice when you use Claude.",
   "long_description": "A fully local writing gate for Claude Desktop. Build a VoiceDNA profile from your own samples, inspect a draft with separate VoiceDNA and AI Editor checks, create a constrained editing brief, and verify a revised candidate. The extension stores no drafts or samples and makes no network requests.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holdyourvoice/hyv",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holdyourvoice/hyv",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holdyourvoice/hyv",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A local-first dual-engine writing gate that protects voice and catches generic AI patterns.",
   "type": "module",
   "bin": { "hyv": "dist/cli.js" },

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -48,6 +48,7 @@ test('uses exit code 2 for a failed candidate gate and 1 for misuse', () => {
     assert.equal(verification.status, 2);
     assert.deepEqual(Object.keys(JSON.parse(verification.stdout)).sort(), ['candidate', 'original', 'passed', 'preservationScore', 'regressions', 'version']);
     assert.equal(run('unknown-command').status, 1);
+    assert.equal(run('mcp', 'unexpected').status, 1);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import { analyze, rewritePrompt, verify } from './pipeline.js';
 import { parseProfile } from './profile.js';
 import { buildProfile } from './voice-dna.js';
 
-const usage = 'Commands: profile, analyze, rewrite-prompt, verify, patterns';
+const usage = 'Commands: profile, analyze, rewrite-prompt, verify, patterns, mcp';
 
 function input(path: string): string {
   return path === '-' ? readFileSync(0, 'utf8') : readFileSync(path, 'utf8');
@@ -37,7 +37,7 @@ function profileArguments(args: string[]): { output: string; samples: string[]; 
   return { output, samples, avoid };
 }
 
-export function runCli(args: string[]): number {
+export async function runCli(args: string[]): Promise<number> {
   const [command, ...rest] = args;
   if (command === 'profile') {
     const { output, samples, avoid } = profileArguments(rest);
@@ -67,12 +67,19 @@ export function runCli(args: string[]): number {
     json({ version: RULESET_VERSION, rules: rules.map(({ expression, ...rule }) => ({ ...rule, expression: expression.source })) });
     return 0;
   }
+  if (command === 'mcp') {
+    if (rest.length > 0) throw new Error('Usage: hyv mcp');
+    await import('./mcp.js');
+    return 0;
+  }
   throw new Error(`${usage}.`);
 }
 
-try {
-  process.exitCode = runCli(process.argv.slice(2));
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-}
+void (async () => {
+  try {
+    process.exitCode = await runCli(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+})();

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -4,7 +4,7 @@ import { once } from 'node:events';
 import test from 'node:test';
 
 test('serves the read-only Claude tools over stdio', async () => {
-  const server = spawn(process.execPath, [new URL('./mcp.js', import.meta.url).pathname], { stdio: ['pipe', 'pipe', 'pipe'] });
+  const server = spawn(process.execPath, [new URL('./cli.js', import.meta.url).pathname, 'mcp'], { stdio: ['pipe', 'pipe', 'pipe'] });
   let stdout = '';
   let stderr = '';
   server.stdout.on('data', (chunk) => { stdout += chunk; });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -16,7 +16,7 @@ function failure(error: unknown) {
   return { content: [{ type: 'text' as const, text: error instanceof Error ? error.message : String(error) }], isError: true };
 }
 
-const server = new McpServer({ name: 'hold-your-voice', version: '3.0.1' });
+const server = new McpServer({ name: 'hold-your-voice', version: '3.0.2' });
 
 server.registerTool('hyv_build_profile', {
   description: 'Build a portable VoiceDNA profile from at least two writing samples. The samples stay in memory and are not saved.',


### PR DESCRIPTION
Adds a free GitHub-hosted Claude Code marketplace and a local Hold Your Voice plugin. The plugin uses npm exec with the pinned public 3.0.2 package to start the local MCP server. Writing stays on the user's device; no Hold Your Voice service receives drafts, samples, profiles, or telemetry.\n\nVerification: npm test (28 passing), release audit, Claude extension packaging, JSON checks, and the stdio integration test that starts the actual hyv mcp command.\n\nThe official Claude validator could not start in this environment because its npx package omitted the platform-native binary; the plugin configuration and actual MCP runtime are covered by the checks above.