### PR TITLE
feat(rewrite): add constrained copy parity harness

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -99,6 +99,33 @@ npx @holdyourvoice/hyv verify draft.md candidate.md profile.json
 
 `verify` returns the original and candidate reports, identifies newly introduced findings, calculates a coarse preservation score, and exits with status `2` when the candidate fails the dual gate. A passing verification automatically records only the resolved finding IDs for that profile in local learning state. It exits with `1` for a usage or runtime error. Treat status `2` as a release signal in scripts or CI.
 
+### Lock factual claims with a CopySpec
+
+Use `verify-spec` when a draft has claims that must remain exact. A local CopySpec records each immutable claim alongside its evidence, then blocks a candidate if that claim is absent, changed, or joined by a prohibited claim.
+
+```json
+{
+  "version": "1",
+  "audience": "operators",
+  "intent": "explain a launch date",
+  "channel": "email",
+  "claims": [
+    {
+      "id": "launch-date",
+      "text": "The launch is on 14 August.",
+      "evidence": "Release calendar, checked 7 August."
+    }
+  ],
+  "prohibitedClaims": ["The launch is guaranteed to double revenue."]
+}
+```
+
+```bash
+hyv verify-spec original.md candidate.md profile.json copy-spec.json
+```
+
+The check is deterministic. It covers declared claims and prohibited text; arbitrary unsupported assertions need a separate factual evaluator.
+
 ### Local voice memory
 
 Learning is on by default. After a successful `verify`, Hold Your Voice records resolved rule IDs under `~/.hyv/learning/`, scoped to a fingerprint of the portable profile. It stores no draft or candidate text. The next `rewrite-prompt` uses a bounded list of those verified repairs.
@@ -199,6 +226,7 @@ The preservation score is a guardrail based on retained original words longer th
 | `hyv analyze <draft> <profile.json>` | Draft and profile | Analysis JSON | You need both reports before editing. |
 | `hyv rewrite-prompt <draft> <profile.json>` | Draft and profile | Markdown editing brief | You need a constrained request for an editor or model. |
 | `hyv verify <original> <candidate> <profile.json>` | Original, candidate, profile | Verification JSON and exit code | You need the candidate gate. |
+| `hyv verify-spec <original> <candidate> <profile.json> <copy-spec.json>` | Original, candidate, profile, CopySpec | Verification JSON with hard claim gate | A brief contains locked facts or prohibited claims. |
 | `hyv learning <show\|add\|clear> <profile.json>` | Profile and optional instruction | Local learning JSON | You need to inspect or manage profile-scoped learning. |
 | `hyv patterns` | None | Ruleset JSON | You need the exact enabled rules. |
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,27 @@
+# rewrite benchmark protocol
+
+This directory is maintainer-only. It evaluates a defined rewrite route; it does not rank models generally or enable provider calls in HYV.
+
+## Artifact boundary
+
+Task packets and captured outputs contain writer text. Keep them local or write them only to an explicit user-chosen destination. HYV does not retain them, include them in learning events, or send them to a provider. Rights-cleared fixtures may live here; client drafts may not.
+
+## Pre-run commitment
+
+Before the locked partition runs, commit a canonical protocol manifest that records its SHA-256 digest, corpus-partition digest, model/settings, reviewer-rubric version, margin, statistic, missing-rating policy, routing policy, and timestamp. A report whose locked artifacts do not match that commitment cannot claim parity.
+
+The initial operator is a HYV maintainer. Prepare a local task, explicitly forward it to a provider, apply the captured response, review any escalation, and own rights-cleared benchmark artifacts. CLI/MCP users are deferred until a locked-test promotion.
+
+## Result states
+
+| condition | state | next action |
+| --- | --- | --- |
+| response-schema failure or one adapter repair attempt | repairable | return stable error and let the caller correct or resubmit |
+| candidate passes all deterministic gates | accepted | eligible for blinded review |
+| VoiceDNA, AI Editor, regression, preservation, or CopySpec failure | needs_escalation | do not auto-repair; caller may use a human or frontier route |
+
+## Locked-test report
+
+For each route, report lower-tier direct, lower-tier accepted after adapter repair, frontier accepted, human accepted, and unresolved separately. Include intent-to-treat approval against the unedited source: hard-gate failures are unapproved, even when excluded from pairwise preference. Review packets contain normalized prose only; no model, repair, source, or run labels. A reviewer sees one candidate per case per round.
+
+Promotion requires the committed confidence method, sample/rating minimums, reviewer aggregation, and missing-data rule. The initial consequence is approval only for the recorded maintainer-run rewrite distribution, never a default runtime model route. A later locked-test failure demotes that route to experimental.

--- a/benchmarks/cases/synthetic-001.json
+++ b/benchmarks/cases/synthetic-001.json
@@ -1,0 +1,15 @@
+{
+  "version": "1",
+  "id": "synthetic-001",
+  "provenance": "Synthetic fixture authored for the rewrite harness.",
+  "partition": "development",
+  "task_class": "locked_claim_and_jargon",
+  "draft": "I leverage the answer with useful detail and clear mechanism. The launch is on 14 August.",
+  "copy_spec": {
+    "version": "1",
+    "audience": "operators",
+    "intent": "explain",
+    "channel": "email",
+    "claims": [{ "id": "launch-date", "text": "The launch is on 14 August.", "evidence": "Synthetic fixture." }]
+  }
+}

--- a/docs/plans/2026-08-07-001-feat-rewrite-parity-harness-plan.md
+++ b/docs/plans/2026-08-07-001-feat-rewrite-parity-harness-plan.md
@@ -1,0 +1,209 @@
+---
+title: "feat: Add a rewrite-first parity harness"
+type: feat
+date: 2026-08-07
+---
+
+# feat: Add a rewrite-first parity harness
+
+## Summary
+
+Add a local, provider-neutral rewrite harness that gives a lower-tier model a constrained task packet, checks its changes, and produces reproducible evidence against a pinned frontier reference. The harness measures non-inferiority on a defined rewrite task; it does not claim general model equivalence.
+
+---
+
+## Problem Frame
+
+HYV already produces a tiered rewrite brief and verifies a resulting candidate through independent VoiceDNA and AI Editor gates. The new CopySpec foundation adds exact immutable-claim and prohibited-claim checks. What is missing is the contract between that brief and an external model response, a bounded repair lifecycle, and a benchmark that can support a specific cost-and-quality decision.
+
+The attachment describes a useful systems pattern: valid data passes unchanged; a validator identifies the exact failing path; a small ordered repair catalog handles only known recoverable shapes; failures return a model-readable explanation. The same pattern applies to a rewrite response, but not to prose itself. The harness must never silently rewrite valid text or present a private internal comparison as a general model ranking.
+
+---
+
+## Requirements
+
+### Task contract and safety
+
+- R1. HYV must create one versioned rewrite task packet containing the original draft, stable sentence map, profile, tiered brief, optional CopySpec, and output policy.
+- R2. A response may change only flagged sentences through numbered replacements; duplicate, unknown, malformed, or clean-sentence replacements must fail before a candidate exists.
+- R3. The response validator must run before repair. It may repair only a recorded, path-specific output-shape failure and must leave a valid response byte-for-byte unchanged.
+- R4. Every candidate must pass the existing VoiceDNA, AI Editor, regression, lexical-preservation, and CopySpec gates before it can be selected or learned from.
+
+### Evidence and evaluation
+
+- R5. The benchmark corpus must contain only synthetic or rights-cleared rewrite packets with provenance, a profile, a CopySpec where factual claims matter, and a fixed reviewer rubric.
+- R6. Every benchmark run must record model identifier and revision, provider, sampling settings, task/brief/validator versions, candidate and repair counts, latency, token use, cost, and deterministic gate results.
+- R7. The evaluation must compare identical frozen packets across a pinned frontier reference, a lower-tier direct baseline, and the lower-tier harness treatment.
+- R8. Blinded human review must be the primary quality decision. The primary outcome is approval without a meaningful edit; factual-error rate, voice fit, AI-editor residue, latency, escalation rate, and cost per approved draft remain separate metrics.
+- R9. A promotion decision requires a pre-registered non-inferiority margin, no factual-error increase, a lower cost per approved draft, and a locked held-out test partition that thresholds cannot tune against.
+
+### Product boundary
+
+- R10. The public HYV runtime must remain provider-neutral, local-first, and free of provider credentials or runtime network calls.
+- R11. CLI and MCP must expose the same prepare, apply, verify, and inspect capabilities over the same local artifacts.
+- R12. Learning and run receipts must remain text-free. Drafts, candidates, prompts, CopySpec evidence, and provider output must not enter local learning state.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[Source draft + profile + optional CopySpec] --> B[Prepare versioned rewrite task]
+  B --> C[External model or human editor]
+  C --> D[Validate response shape]
+  D -->|valid| E[Apply numbered replacements]
+  D -->|known path failure| F[Targeted adapter repair]
+  F --> D
+  D -->|unknown or exhausted failure| G[Return actionable failure]
+  E --> H[VoiceDNA + AI Editor + regression + lexical-preservation + CopySpec gates]
+  H -->|all pass| I[Return candidate and text-free receipt]
+  H -->|repairable and budget remains| G
+  H -->|risk or budget exhausted| J[Mark for human or frontier escalation]
+  I --> K[Capture benchmark evidence]
+  J --> K
+```
+
+The model receives a task contract and returns a replacement payload. HYV owns parsing, deterministic repair, application, verification, and evidence collection. A caller outside HYV owns any provider invocation or escalation.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Build a rewrite-only harness before fresh drafting.** A source draft gives every case a stable preservation target and makes factual regressions observable.
+- KTD2. **Keep provider calls outside the package.** This preserves the local-first release boundary and makes the benchmark runner accept captured outputs from any approved provider.
+- KTD3. **Use validate-then-repair, not universal preprocessing.** The schema localizes a failure; a repair is permitted only for a known response path and must create an audit event.
+- KTD4. **Treat CopySpec as a hard but narrow factual gate.** It verifies declared immutable and prohibited text. Human review or a separately validated factual evaluator must assess unsupported paraphrases and new assertions.
+- KTD5. **Use hard gates before quality comparison.** A fluent candidate with a claim failure has failed; it must not be rescued by a composite score or a model judge.
+- KTD6. **Pre-register the benchmark before running the held-out suite.** Freeze the corpus partitions, model settings, reviewer rubric, meaningful-edit definition, margin, and escalation policy before results exist.
+- KTD7. **Return an escalation classification, not an automatic provider route.** The package may label a candidate `accepted`, `repairable`, or `needs_escalation`; the caller retains cost and provider authority.
+
+---
+
+## Implementation Units
+
+### U1. Stabilize CopySpec as the factual plane
+
+- **Goal:** Make the existing CopySpec foundation a declared prerequisite for the harness and close its deterministic edge cases.
+- **Requirements:** R4, R5, R12.
+- **Dependencies:** None.
+- **Files:** `src/copy-spec.ts`, `src/contracts.ts`, `src/pipeline.ts`, `src/pipeline.test.ts`, `src/cli.test.ts`.
+- **Approach:** Keep immutable and prohibited claims fail-closed. Add structured failure categories and sentence-to-claim audit links without representing exact text checks as semantic factuality.
+- **Patterns to follow:** Existing `verifyWithCopySpec`, `Verification`, and focused Node test patterns.
+- **Test scenarios:** A mutable claim may be absent; immutable claims spanning punctuation normalize predictably; multiple claims map to one sentence; malformed or duplicate claim IDs fail before verification; a passing voice result still fails on a claim failure.
+- **Verification:** CopySpec fixtures demonstrate declared-claim enforcement and preserve the existing exit-code contract.
+
+### U2. Add a versioned rewrite task and strict replacement applicator
+
+- **Goal:** Turn the current prose brief into a deterministic handoff and apply only authorized replacements.
+- **Requirements:** R1, R2, R3, R4, R12.
+- **Dependencies:** U1.
+- **Files:** `src/contracts.ts`, `src/rewrite-task.ts`, `src/pipeline.ts`, `src/text.ts`, `src/rewrite-task.test.ts`, `src/pipeline.test.ts`.
+- **Approach:** Define a versioned task manifest with sentence indices, eligible sentence IDs, the existing prompt contract, optional CopySpec, and bounded repair policy. Parse model responses into replacements, reject changes outside the eligible set, then apply replacements from the original text rather than accepting a full rewritten document.
+- **Patterns to follow:** Stable sentence offsets in `src/text.ts`; tier ordering in `docs/PROMPT-CONTRACT.md`; parser validation in `src/profile.ts` and `src/copy-spec.ts`.
+- **Test scenarios:** Valid numbered replacements preserve every clean sentence; duplicate or out-of-range sentence IDs fail; a stringified replacement list repairs only after schema rejection; a valid response bypasses all adapters; an adapter cannot alter replacement content outside its known shape fix.
+- **Verification:** The same task and response yield a byte-identical candidate across repeated runs, with an audit record of any applied adapter.
+
+### U3. Expose task lifecycle parity through CLI and MCP
+
+- **Goal:** Let a human, script, or MCP client prepare and verify the same task without adding a model provider to HYV.
+- **Requirements:** R1, R4, R10, R11, R12.
+- **Dependencies:** U2.
+- **Files:** `src/cli.ts`, `src/mcp-tools.ts`, `src/mcp.ts`, `src/cli.test.ts`, `src/mcp-tools.test.ts`, `src/mcp.test.ts`, `Readme.md`, `docs/PROMPT-CONTRACT.md`.
+- **Approach:** Add paired prepare and apply commands/tools backed by shared pipeline functions. Keep the current human-readable rewrite prompt as a compatibility surface. Return actionable rule IDs, claim IDs, and sentence numbers when a candidate is repairable or needs escalation.
+- **Patterns to follow:** Existing CLI/MCP adapter split, exact MCP tool-order coverage, and candidate-gate exit status `2`.
+- **Test scenarios:** CLI and MCP serialize the same canonical task; both reject the same malformed response; a CopySpec reaches the MCP preparation path; a failed apply creates no learning event; existing commands remain compatible.
+- **Verification:** Contract tests prove parity without a provider key, network request, or persisted text artifact.
+
+### U4. Add bounded run receipts and escalation classification
+
+- **Goal:** Make a completed task auditable without storing the writer's text or silently retrying a weak model.
+- **Requirements:** R3, R4, R9, R12.
+- **Dependencies:** U2, U3.
+- **Files:** `src/contracts.ts`, `src/pipeline.ts`, `src/learning.ts`, `src/learning.test.ts`, `src/pipeline.test.ts`.
+- **Approach:** Represent `accepted`, `repairable`, and `needs_escalation` as result states derived from deterministic failures and a one-repair default. Store only profile/task fingerprints, validator versions, failure categories, and final state after successful verification.
+- **Patterns to follow:** Bounded, profile-fingerprinted, text-free learning events in `src/learning.ts`.
+- **Test scenarios:** A repeated failed response never increases confidence; a repaired pass creates one receipt; claim ambiguity produces `needs_escalation`; a final pass cannot record draft, candidate, evidence, prompt, or provider text.
+- **Verification:** Receipt fixtures prove deduplication, bounded storage, and no text leakage.
+
+### U5. Build the reproducible rewrite benchmark harness
+
+- **Goal:** Evaluate captured frontier and lower-tier outputs under identical task contracts without placing credentialed generation in the runtime package.
+- **Requirements:** R5, R6, R7, R8, R9, R10.
+- **Dependencies:** U1, U2, U4.
+- **Files:** `benchmarks/README.md`, `benchmarks/schema/`, `benchmarks/cases/`, `benchmarks/reviews/`, `scripts/evaluate-rewrite-benchmark.mjs`, `src/benchmark.test.ts`, `docs/BENCHMARKS.md`.
+- **Approach:** Define versioned task, captured-output, review, and aggregate-report manifests. Split cases by writer and topic into development, calibration, and locked-test partitions. Run existing deterministic gates for every captured output, create randomized blind labels for eligible outputs, and calculate paired quality, factuality, latency, and cost metrics separately.
+- **Patterns to follow:** Provenance and reproducibility requirements already stated in `docs/BENCHMARKS.md`; release audit boundary in `scripts/release-audit.mjs`.
+- **Test scenarios:** A report rejects missing provenance, model settings, human rating, or blind label; a case cannot appear in both calibration and locked test; a failing hard gate is excluded from preference selection but remains counted in factual metrics; results remain reproducible from fixed manifests.
+- **Verification:** A synthetic fixture corpus produces a complete report, while missing evidence prevents a parity conclusion.
+
+### U6. Publish a promotion rule and limitations report
+
+- **Goal:** Make model-selection decisions repeatable and keep external claims within the observed benchmark.
+- **Requirements:** R6, R8, R9, R10.
+- **Dependencies:** U5.
+- **Files:** `docs/BENCHMARKS.md`, `docs/wiki/Benchmarks-and-Research.md`, `Readme.md`, `benchmarks/README.md`.
+- **Approach:** Document the frozen protocol, review rubric, pre-registered non-inferiority margin, promotion rule, and failure taxonomy. Report the frontier and lower-tier paths by exact model/settings and task distribution. Publish only rights-permitted artifacts.
+- **Patterns to follow:** The existing distinction between historical context and reproducible evidence in `docs/BENCHMARKS.md`.
+- **Test scenarios:** Documentation examples use the same manifest fields as the validator; reports without a locked-test result or factual metric cannot use a parity or superiority conclusion.
+- **Verification:** A reviewer can reproduce the decision from the manifest, outputs, blind-review records, and report without access to client drafts.
+
+---
+
+## Benchmark Protocol
+
+Use a fixed, rewrite-only corpus stratified across five failure classes: locked names/dates/numbers, voice mismatch and AI-editor residue, minimal-change drafts with many clean sentences, dense factual and formatting constraints, and editorial cases that require author preference.
+
+For every packet, capture four paths with identical source material and task contract: the unedited source, the pinned frontier reference, the lower-tier direct baseline, and the lower-tier harness treatment. Provider/model identity, revision, context window, tool mode, prompt version, temperature, seed where available, token counts, price basis, and run timestamp are mandatory fields.
+
+Blind reviewers see randomized outputs and the fixed meaningful-edit rubric, never model identity or treatment. The review form records approval without meaningful edit, pairwise preference where both candidates pass hard gates, factual errors by category, and whether an escalation would have been appropriate. Calibration chooses the escalation threshold; locked-test results only evaluate it.
+
+---
+
+## Promotion Rule
+
+Promote the lower-tier harness only when all pre-registered conditions hold on the locked test partition:
+
+1. Its approval-without-meaningful-edit result remains inside the declared non-inferiority margin against the pinned frontier path.
+2. Its factual-error rate does not increase.
+3. Its cost per approved draft is lower after candidate, repair, and escalation costs.
+4. The report includes enough provenance to reproduce every included result.
+
+The permitted statement is bounded: “This lower-tier harness met the declared rewrite benchmark under the recorded settings and routing policy.”
+
+---
+
+## Scope Boundaries
+
+### In scope
+
+- Rewrite-first task preparation, exact replacement application, deterministic validation, bounded repair feedback, provider-neutral evidence capture, blind review, and a promotion decision.
+
+### Deferred to follow-up work
+
+- Fresh-draft generation, a semantic factuality evaluator, a calibrated model-based judge, training or fine-tuning, and automatic model-provider escalation.
+
+### Outside this product's identity
+
+- Provider credentials, hosted client content, runtime network calls in `src/`, hidden full-text memory, and broad claims that one model is generally better than another.
+
+---
+
+## Risks and Dependencies
+
+- The uncommitted CopySpec foundation in the current worktree is a prerequisite. Fold it into the first implementation change or commit it before treating this plan as a clean baseline.
+- Exact CopySpec matching catches declared facts but cannot prove semantic entailment. Keep the factual-error rubric and human review mandatory.
+- One repair pass controls cost and prevents retry-based score inflation, but calibration may show that some output-shape errors need a different adapter or an earlier escalation category.
+- Blind author review is scarce. Start with a small rights-cleared corpus, measure reviewer agreement, and do not publish a comparison until the locked partition has enough completed ratings for the pre-registered analysis.
+- Model aliases and provider behavior drift. Every report must pin the exact model/version and generation configuration; a vendor label alone is not reproducible.
+
+---
+
+## Sources and Research
+
+- HYV technical harness: the linked Notion page, “Making a Lower-Tier Model Reach Frontier Copy Quality — Technical Harness.”
+- Attachment: `pasted-text.txt`, which motivates validator-localized repair and transparent defaults; its internal 6/10 result is unverified outside that system.
+- [OpenAI: Working with evals](https://developers.openai.com/api/docs/guides/evals) supports task-defined evaluation, running the eval, analyzing results, and iterating; the page also announces its legacy Evals platform retirement schedule, so this plan uses provider-neutral local manifests.
+- [Anthropic: Tool use with Claude](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview) documents schema-bound tool inputs, tool-result loops, and strict schema conformance; this informs the response contract, not a provider dependency.
+- [Google: Structured outputs](https://ai.google.dev/gemini-api/docs/structured-output) states that syntactically valid schema output still needs application-level semantic validation.
+- [Self-Refine](https://arxiv.org/abs/2303.17651) supports the use of bounded, actionable feedback and selection, while also documenting that weak models may fail to follow refinement instructions.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -71,6 +71,25 @@ test('fails the CopySpec gate when a locked claim changes', () => {
   }
 });
 
+test('prepares and applies the same constrained rewrite task without a provider call', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'holdyourvoice-cli-'));
+  try {
+    const first = join(directory, 'first.md'); const second = join(directory, 'second.md'); const profile = join(directory, 'profile.json');
+    const draft = join(directory, 'draft.md'); const task = join(directory, 'task.json'); const response = join(directory, 'response.json');
+    writeFileSync(first, 'I write plainly. I name the work.'); writeFileSync(second, 'I keep the mechanism clear. I avoid filler.');
+    writeFileSync(draft, 'I leverage the answer with useful detail and clear mechanism.');
+    assert.equal(run(['profile', profile, first, second, '--avoid=leverage']).status, 0);
+    assert.equal(run(['prepare-rewrite', draft, profile, task]).status, 0);
+    const prepared = JSON.parse(readFileSync(task, 'utf8'));
+    writeFileSync(response, JSON.stringify({ version: '1', taskFingerprint: prepared.fingerprint, replacements: [{ sentenceId: 1, text: 'I use the answer with useful detail and clear mechanism.' }] }));
+    const result = run(['apply-rewrite', task, response, profile]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).candidate, 'I use the answer with useful detail and clear mechanism.');
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test('rejects a malformed hand-edited profile before analysis', () => {
   const directory = mkdtempSync(join(tmpdir(), 'holdyourvoice-cli-'));
   try {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -83,8 +83,10 @@ test('prepares and applies the same constrained rewrite task without a provider 
     const prepared = JSON.parse(readFileSync(task, 'utf8'));
     writeFileSync(response, JSON.stringify({ version: '1', taskFingerprint: prepared.fingerprint, replacements: [{ sentenceId: 1, text: 'I use the answer with useful detail and clear mechanism.' }] }));
     const result = run(['apply-rewrite', task, response, profile]);
-    assert.equal(result.status, 0, result.stderr);
-    assert.equal(JSON.parse(result.stdout).candidate, 'I use the answer with useful detail and clear mechanism.');
+    assert.equal(result.status, 2, result.stderr);
+    const applied = JSON.parse(result.stdout);
+    assert.equal(applied.status, 'needs_semantic_review');
+    assert.equal(applied.candidate, 'I use the answer with useful detail and clear mechanism.');
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -54,6 +54,23 @@ test('uses exit code 2 for a failed candidate gate and 1 for misuse', () => {
   }
 });
 
+test('fails the CopySpec gate when a locked claim changes', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'holdyourvoice-cli-'));
+  try {
+    const first = join(directory, 'first.md'); const second = join(directory, 'second.md'); const profile = join(directory, 'profile.json');
+    const original = join(directory, 'original.md'); const candidate = join(directory, 'candidate.md'); const spec = join(directory, 'copy-spec.json');
+    writeFileSync(first, 'I write plainly. I name the work.'); writeFileSync(second, 'I keep the mechanism clear. I avoid filler.');
+    writeFileSync(original, 'The launch is on 14 August.'); writeFileSync(candidate, 'The launch is next month.');
+    writeFileSync(spec, JSON.stringify({ version: '1', audience: 'operators', intent: 'explain', channel: 'email', claims: [{ id: 'launch-date', text: 'The launch is on 14 August.', evidence: 'Release calendar.' }] }));
+    assert.equal(run(['profile', profile, first, second]).status, 0);
+    const result = run(['verify-spec', original, candidate, profile, spec]);
+    assert.equal(result.status, 2);
+    assert.equal(JSON.parse(result.stdout).claims.failures[0].code, 'missing_immutable_claim');
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test('rejects a malformed hand-edited profile before analysis', () => {
   const directory = mkdtempSync(join(tmpdir(), 'holdyourvoice-cli-'));
   try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 import { readFileSync, writeFileSync } from 'node:fs';
 import { rules, RULESET_VERSION } from './ai-editor.js';
+import { parseCopySpec } from './copy-spec.js';
 import type { Profile } from './contracts.js';
 import { addLearningInstruction, clearLearning, composeLearning, profileFingerprint, recordVerifiedCandidate } from './learning.js';
-import { analyze, rewritePrompt, verify } from './pipeline.js';
+import { analyze, rewritePrompt, verify, verifyWithCopySpec } from './pipeline.js';
 import { parseProfile } from './profile.js';
 import { buildProfile } from './voice-dna.js';
 
-const usage = 'Commands: profile, analyze, rewrite-prompt, verify, learning, patterns, mcp';
+const usage = 'Commands: profile, analyze, rewrite-prompt, verify, verify-spec, learning, patterns, mcp';
 
 function input(path: string): string {
   return path === '-' ? readFileSync(0, 'utf8') : readFileSync(path, 'utf8');
@@ -67,6 +68,19 @@ export async function runCli(args: string[]): Promise<number> {
     const result = verify(originalText, candidateText, profile);
     const learning = recordVerifiedCandidate(profile, result, candidateText);
     if (learning === 'write_failed') console.error('Warning: verification passed, but local learning could not be saved.');
+    json(result);
+    return result.passed ? 0 : 2;
+  }
+  if (command === 'verify-spec') {
+    const [original, candidate, profilePath, specPath] = rest;
+    if (!original || !candidate || !profilePath || !specPath) throw new Error('Usage: hyv verify-spec original.md candidate.md profile.json copy-spec.json');
+    const profile = readProfile(profilePath);
+    const candidateText = input(candidate);
+    const result = verifyWithCopySpec(input(original), candidateText, profile, parseCopySpec(JSON.parse(input(specPath))));
+    if (result.passed) {
+      const learning = recordVerifiedCandidate(profile, result, candidateText);
+      if (learning === 'write_failed') console.error('Warning: verification passed, but local learning could not be saved.');
+    }
     json(result);
     return result.passed ? 0 : 2;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,9 +6,10 @@ import type { Profile } from './contracts.js';
 import { addLearningInstruction, clearLearning, composeLearning, profileFingerprint, recordVerifiedCandidate } from './learning.js';
 import { analyze, rewritePrompt, verify, verifyWithCopySpec } from './pipeline.js';
 import { parseProfile } from './profile.js';
+import { evaluateRewriteResponse, parseRewriteTask, prepareRewriteTask } from './rewrite-task.js';
 import { buildProfile } from './voice-dna.js';
 
-const usage = 'Commands: profile, analyze, rewrite-prompt, verify, verify-spec, learning, patterns, mcp';
+const usage = 'Commands: profile, analyze, rewrite-prompt, prepare-rewrite, apply-rewrite, verify, verify-spec, learning, patterns, mcp';
 
 function input(path: string): string {
   return path === '-' ? readFileSync(0, 'utf8') : readFileSync(path, 'utf8');
@@ -58,6 +59,21 @@ export async function runCli(args: string[]): Promise<number> {
     const profile = readProfile(profilePath);
     console.log(rewritePrompt(input(draft), profile, composeLearning(profile)));
     return 0;
+  }
+  if (command === 'prepare-rewrite') {
+    const [draft, profilePath, output, specPath] = rest;
+    if (!draft || !profilePath || !output) throw new Error('Usage: hyv prepare-rewrite draft.md profile.json task.json [copy-spec.json]');
+    const task = prepareRewriteTask(input(draft), readProfile(profilePath), specPath ? parseCopySpec(JSON.parse(input(specPath))) : undefined);
+    writeFileSync(output, `${JSON.stringify(task, null, 2)}\n`);
+    json({ version: task.version, fingerprint: task.fingerprint, eligibleSentenceIds: task.eligibleSentenceIds });
+    return 0;
+  }
+  if (command === 'apply-rewrite') {
+    const [taskPath, responsePath, profilePath] = rest;
+    if (!taskPath || !responsePath || !profilePath) throw new Error('Usage: hyv apply-rewrite task.json response.json profile.json');
+    const result = evaluateRewriteResponse(parseRewriteTask(JSON.parse(input(taskPath))), input(responsePath), readProfile(profilePath));
+    json(result);
+    return result.status === 'accepted' ? 0 : 2;
   }
   if (command === 'verify') {
     const [original, candidate, profilePath] = rest;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -97,3 +97,57 @@ export interface ClaimVerification {
 export interface CopySpecVerification extends Verification {
   claims: ClaimVerification;
 }
+
+export interface RewriteTaskSentence {
+  id: number;
+  text: string;
+  eligible: boolean;
+}
+
+export interface RewriteTask {
+  version: '1';
+  fingerprint: string;
+  draft: string;
+  sentences: RewriteTaskSentence[];
+  eligibleSentenceIds: number[];
+  prompt: string;
+  copySpec?: CopySpec;
+}
+
+export interface RewriteReplacement {
+  sentenceId: number;
+  text: string;
+}
+
+export interface RewriteResponse {
+  version: '1';
+  taskFingerprint: string;
+  replacements: RewriteReplacement[];
+}
+
+export type RewriteFailureCode = 'invalid_json' | 'invalid_response_shape' | 'invalid_response_version' | 'task_fingerprint_mismatch' | 'duplicate_sentence_id' | 'unknown_sentence_id' | 'ineligible_sentence_id' | 'invalid_replacement_text' | 'response_too_large';
+
+export interface RewriteFailure {
+  code: RewriteFailureCode;
+  message: string;
+  path?: string;
+}
+
+export interface RewriteReceipt {
+  version: '1';
+  taskFingerprint: string;
+  responseFingerprint: string;
+  adapterIds: string[];
+}
+
+export interface RewriteApplyResult {
+  status: 'accepted' | 'repairable';
+  candidate?: string;
+  failures: RewriteFailure[];
+  receipt: RewriteReceipt;
+}
+
+export interface RewriteEvaluation extends Omit<RewriteApplyResult, 'status'> {
+  status: 'accepted' | 'repairable' | 'needs_escalation';
+  verification?: Verification | CopySpecVerification;
+}

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -151,3 +151,17 @@ export interface RewriteEvaluation extends Omit<RewriteApplyResult, 'status'> {
   status: 'accepted' | 'repairable' | 'needs_escalation' | 'needs_semantic_review';
   verification?: Verification | CopySpecVerification;
 }
+
+export type SemanticViolation = 'action_change' | 'dropped_object' | 'unsupported_claim' | 'constraint_weakened' | 'clarity_regression';
+
+export interface SemanticVerdict {
+  evaluatorId: string;
+  approved: boolean;
+  violations: SemanticViolation[];
+}
+
+export interface SemanticReview {
+  status: 'accepted' | 'needs_escalation';
+  verdicts: SemanticVerdict[];
+  reason?: 'insufficient_evaluators' | 'evaluator_disagreement' | 'semantic_violation';
+}

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -64,3 +64,36 @@ export interface Verification {
   regressions: Finding[];
   passed: boolean;
 }
+
+export interface CopyClaim {
+  id: string;
+  text: string;
+  evidence: string;
+  mutable?: boolean;
+}
+
+export interface CopySpec {
+  version: '1';
+  audience: string;
+  intent: string;
+  channel: string;
+  claims: CopyClaim[];
+  prohibitedClaims?: string[];
+}
+
+export interface ClaimFailure {
+  id: string;
+  code: 'missing_immutable_claim' | 'prohibited_claim';
+  message: string;
+  evidence?: string;
+}
+
+export interface ClaimVerification {
+  passed: boolean;
+  failures: ClaimFailure[];
+  sentenceClaims: Record<number, string[]>;
+}
+
+export interface CopySpecVerification extends Verification {
+  claims: ClaimVerification;
+}

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -148,6 +148,6 @@ export interface RewriteApplyResult {
 }
 
 export interface RewriteEvaluation extends Omit<RewriteApplyResult, 'status'> {
-  status: 'accepted' | 'repairable' | 'needs_escalation';
+  status: 'accepted' | 'repairable' | 'needs_escalation' | 'needs_semantic_review';
   verification?: Verification | CopySpecVerification;
 }

--- a/src/copy-spec.ts
+++ b/src/copy-spec.ts
@@ -1,0 +1,54 @@
+import type { ClaimFailure, ClaimVerification, CopyClaim, CopySpec } from './contracts.js';
+import { sentences } from './text.js';
+
+function normalized(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function isText(value: unknown, limit: number): value is string {
+  return typeof value === 'string' && value.trim().length > 0 && value.length <= limit;
+}
+
+function isClaim(value: unknown): value is CopyClaim {
+  if (!value || typeof value !== 'object') return false;
+  const claim = value as Partial<CopyClaim>;
+  return isText(claim.id, 100) && /^[A-Za-z0-9._-]+$/.test(claim.id)
+    && isText(claim.text, 2_000) && isText(claim.evidence, 4_000)
+    && (claim.mutable === undefined || typeof claim.mutable === 'boolean');
+}
+
+export function parseCopySpec(value: unknown): CopySpec {
+  if (!value || typeof value !== 'object') throw new Error('CopySpec must be a JSON object.');
+  const spec = value as Partial<CopySpec>;
+  if (spec.version !== '1' || !isText(spec.audience, 500) || !isText(spec.intent, 500) || !isText(spec.channel, 100)
+    || !Array.isArray(spec.claims) || spec.claims.length === 0 || spec.claims.length > 100 || !spec.claims.every(isClaim)
+    || new Set(spec.claims.map((claim) => claim.id)).size !== spec.claims.length
+    || (spec.prohibitedClaims !== undefined && (!Array.isArray(spec.prohibitedClaims) || spec.prohibitedClaims.length > 100 || !spec.prohibitedClaims.every((claim) => isText(claim, 2_000))))) {
+    throw new Error('CopySpec is not valid. It needs version "1", audience, intent, channel, unique claims with text and evidence, and optional prohibitedClaims.');
+  }
+  return spec as CopySpec;
+}
+
+export function verifyClaims(candidate: string, spec: CopySpec): ClaimVerification {
+  const draftSentences = sentences(candidate);
+  const normalizedCandidate = normalized(candidate);
+  const sentenceClaims: Record<number, string[]> = {};
+  const failures: ClaimFailure[] = [];
+
+  for (const claim of spec.claims) {
+    const claimText = normalized(claim.text);
+    const matching = draftSentences.filter((sentence) => normalized(sentence.text).includes(claimText));
+    for (const sentence of matching) (sentenceClaims[sentence.index] ??= []).push(claim.id);
+    if (!claim.mutable && matching.length === 0) {
+      failures.push({ id: claim.id, code: 'missing_immutable_claim', message: `Immutable claim ${claim.id} is absent or changed.`, evidence: claim.evidence });
+    }
+  }
+
+  for (const claim of spec.prohibitedClaims ?? []) {
+    if (normalizedCandidate.includes(normalized(claim))) {
+      failures.push({ id: claim, code: 'prohibited_claim', message: `Prohibited claim appears in the candidate: ${claim}` });
+    }
+  }
+
+  return { passed: failures.length === 0, failures, sentenceClaims };
+}

--- a/src/mcp-tools.test.ts
+++ b/src/mcp-tools.test.ts
@@ -52,6 +52,6 @@ test('prepares and applies the rewrite task through MCP helpers', () => {
   const result = applyRewriteForMcp(JSON.stringify(task), JSON.stringify({
     version: '1', taskFingerprint: task.fingerprint, replacements: [{ sentenceId: 1, text: 'I use the answer with useful detail and clear mechanism.' }],
   }), profileJson);
-  assert.equal(result.status, 'accepted');
+  assert.equal(result.status, 'needs_semantic_review');
   assert.equal(result.candidate, 'I use the answer with useful detail and clear mechanism.');
 });

--- a/src/mcp-tools.test.ts
+++ b/src/mcp-tools.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import { analyzeForMcp, buildProfileForMcp, patternsForMcp, rewritePromptForMcp, verifyCopySpecForMcp, verifyForMcp } from './mcp-tools.js';
+import { analyzeForMcp, applyRewriteForMcp, buildProfileForMcp, patternsForMcp, prepareRewriteForMcp, rewritePromptForMcp, verifyCopySpecForMcp, verifyForMcp } from './mcp-tools.js';
 
 const profile = buildProfileForMcp(['I write clearly. I keep the useful detail.', 'I make the call. Then I explain the trade-off.'], ['leverage']);
 const profileJson = JSON.stringify(profile);
@@ -45,4 +45,13 @@ test('fails closed on changed CopySpec claims through MCP tools', () => {
   assert.equal(result.passed, false);
   assert.equal(result.claims.failures[0]?.code, 'missing_immutable_claim');
   assert.equal(result.learning, 'nothing_to_learn');
+});
+
+test('prepares and applies the rewrite task through MCP helpers', () => {
+  const task = prepareRewriteForMcp('I leverage the answer with useful detail and clear mechanism.', profileJson);
+  const result = applyRewriteForMcp(JSON.stringify(task), JSON.stringify({
+    version: '1', taskFingerprint: task.fingerprint, replacements: [{ sentenceId: 1, text: 'I use the answer with useful detail and clear mechanism.' }],
+  }), profileJson);
+  assert.equal(result.status, 'accepted');
+  assert.equal(result.candidate, 'I use the answer with useful detail and clear mechanism.');
 });

--- a/src/mcp-tools.test.ts
+++ b/src/mcp-tools.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import { analyzeForMcp, buildProfileForMcp, patternsForMcp, rewritePromptForMcp, verifyForMcp } from './mcp-tools.js';
+import { analyzeForMcp, buildProfileForMcp, patternsForMcp, rewritePromptForMcp, verifyCopySpecForMcp, verifyForMcp } from './mcp-tools.js';
 
 const profile = buildProfileForMcp(['I write clearly. I keep the useful detail.', 'I make the call. Then I explain the trade-off.'], ['leverage']);
 const profileJson = JSON.stringify(profile);
@@ -35,4 +35,14 @@ test('creates and verifies an editing loop through MCP tools', () => {
 
 test('exposes the executable pattern IDs through MCP tools', () => {
   assert.ok(patternsForMcp().rules.some((rule) => rule.id === 'ai.leverage'));
+});
+
+test('fails closed on changed CopySpec claims through MCP tools', () => {
+  const result = verifyCopySpecForMcp('The launch is on 14 August.', 'The launch is next month.', profileJson, JSON.stringify({
+    version: '1', audience: 'operators', intent: 'explain', channel: 'email',
+    claims: [{ id: 'launch-date', text: 'The launch is on 14 August.', evidence: 'Release calendar.' }],
+  }));
+  assert.equal(result.passed, false);
+  assert.equal(result.claims.failures[0]?.code, 'missing_immutable_claim');
+  assert.equal(result.learning, 'nothing_to_learn');
 });

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -1,6 +1,7 @@
 import { rules, RULESET_VERSION } from './ai-editor.js';
+import { parseCopySpec } from './copy-spec.js';
 import { composeLearning, type LearningOptions, recordVerifiedCandidate } from './learning.js';
-import { analyze, rewritePrompt, verify } from './pipeline.js';
+import { analyze, rewritePrompt, verify, verifyWithCopySpec } from './pipeline.js';
 import { parseProfile } from './profile.js';
 import { buildProfile } from './voice-dna.js';
 
@@ -9,6 +10,14 @@ function profileFromJson(profileJson: string) {
     return parseProfile(JSON.parse(profileJson));
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Profile is not valid JSON.');
+  }
+}
+
+function copySpecFromJson(copySpecJson: string) {
+  try {
+    return parseCopySpec(JSON.parse(copySpecJson));
+  } catch (error) {
+    throw new Error(error instanceof Error ? error.message : 'CopySpec is not valid JSON.');
   }
 }
 
@@ -29,6 +38,12 @@ export function verifyForMcp(original: string, candidate: string, profileJson: s
   const profile = profileFromJson(profileJson);
   const result = verify(original, candidate, profile);
   return { ...result, learning: recordVerifiedCandidate(profile, result, candidate, options) };
+}
+
+export function verifyCopySpecForMcp(original: string, candidate: string, profileJson: string, copySpecJson: string, options: LearningOptions = {}) {
+  const profile = profileFromJson(profileJson);
+  const result = verifyWithCopySpec(original, candidate, profile, copySpecFromJson(copySpecJson));
+  return { ...result, learning: result.passed ? recordVerifiedCandidate(profile, result, candidate, options) : 'nothing_to_learn' };
 }
 
 export function patternsForMcp() {

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -3,6 +3,7 @@ import { parseCopySpec } from './copy-spec.js';
 import { composeLearning, type LearningOptions, recordVerifiedCandidate } from './learning.js';
 import { analyze, rewritePrompt, verify, verifyWithCopySpec } from './pipeline.js';
 import { parseProfile } from './profile.js';
+import { evaluateRewriteResponse, parseRewriteTask, prepareRewriteTask } from './rewrite-task.js';
 import { buildProfile } from './voice-dna.js';
 
 function profileFromJson(profileJson: string) {
@@ -32,6 +33,14 @@ export function analyzeForMcp(draft: string, profileJson: string) {
 export function rewritePromptForMcp(draft: string, profileJson: string, options: LearningOptions = {}) {
   const profile = profileFromJson(profileJson);
   return { prompt: rewritePrompt(draft, profile, composeLearning(profile, options)) };
+}
+
+export function prepareRewriteForMcp(draft: string, profileJson: string, copySpecJson?: string) {
+  return prepareRewriteTask(draft, profileFromJson(profileJson), copySpecJson ? copySpecFromJson(copySpecJson) : undefined);
+}
+
+export function applyRewriteForMcp(taskJson: string, responseJson: string, profileJson: string) {
+  return evaluateRewriteResponse(parseRewriteTask(JSON.parse(taskJson)), responseJson, profileFromJson(profileJson));
 }
 
 export function verifyForMcp(original: string, candidate: string, profileJson: string, options: LearningOptions = {}) {

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -23,7 +23,7 @@ test('serves local Claude tools over stdio', async () => {
   assert.equal(code, 0);
   const responses = stdout.trim().split('\n').map((line) => JSON.parse(line) as { id: number; result?: { tools?: Array<{ name: string; annotations?: { readOnlyHint?: boolean } }> } });
   const tools = responses.find((response) => response.id === 2)?.result?.tools;
-  assert.deepEqual(tools?.map((tool) => tool.name), ['hyv_build_profile', 'hyv_analyze', 'hyv_rewrite_prompt', 'hyv_verify', 'hyv_verify_copy_spec', 'hyv_patterns']);
+  assert.deepEqual(tools?.map((tool) => tool.name), ['hyv_build_profile', 'hyv_analyze', 'hyv_rewrite_prompt', 'hyv_prepare_rewrite', 'hyv_apply_rewrite', 'hyv_verify', 'hyv_verify_copy_spec', 'hyv_patterns']);
   assert.ok(tools?.filter((tool) => tool.name !== 'hyv_verify' && tool.name !== 'hyv_verify_copy_spec').every((tool) => tool.annotations?.readOnlyHint));
   assert.equal(tools?.find((tool) => tool.name === 'hyv_verify')?.annotations?.readOnlyHint, false);
   assert.equal(tools?.find((tool) => tool.name === 'hyv_verify_copy_spec')?.annotations?.readOnlyHint, false);

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -23,9 +23,10 @@ test('serves local Claude tools over stdio', async () => {
   assert.equal(code, 0);
   const responses = stdout.trim().split('\n').map((line) => JSON.parse(line) as { id: number; result?: { tools?: Array<{ name: string; annotations?: { readOnlyHint?: boolean } }> } });
   const tools = responses.find((response) => response.id === 2)?.result?.tools;
-  assert.deepEqual(tools?.map((tool) => tool.name), ['hyv_build_profile', 'hyv_analyze', 'hyv_rewrite_prompt', 'hyv_verify', 'hyv_patterns']);
-  assert.ok(tools?.filter((tool) => tool.name !== 'hyv_verify').every((tool) => tool.annotations?.readOnlyHint));
+  assert.deepEqual(tools?.map((tool) => tool.name), ['hyv_build_profile', 'hyv_analyze', 'hyv_rewrite_prompt', 'hyv_verify', 'hyv_verify_copy_spec', 'hyv_patterns']);
+  assert.ok(tools?.filter((tool) => tool.name !== 'hyv_verify' && tool.name !== 'hyv_verify_copy_spec').every((tool) => tool.annotations?.readOnlyHint));
   assert.equal(tools?.find((tool) => tool.name === 'hyv_verify')?.annotations?.readOnlyHint, false);
+  assert.equal(tools?.find((tool) => tool.name === 'hyv_verify_copy_spec')?.annotations?.readOnlyHint, false);
 });
 
 test('uses default local learning through the registered MCP tools', async () => {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,10 +1,11 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { analyzeForMcp, buildProfileForMcp, patternsForMcp, rewritePromptForMcp, verifyForMcp } from './mcp-tools.js';
+import { analyzeForMcp, buildProfileForMcp, patternsForMcp, rewritePromptForMcp, verifyCopySpecForMcp, verifyForMcp } from './mcp-tools.js';
 
 const writing = z.string().min(1).max(100_000);
 const profileJson = z.string().min(1).max(50_000);
+const copySpecJson = z.string().min(1).max(250_000);
 const samples = z.array(writing).min(2).max(20);
 const avoid = z.array(z.string().min(1).max(200)).max(50).optional();
 
@@ -61,6 +62,18 @@ server.registerTool('hyv_verify', {
 }, async ({ original, candidate, profile_json }) => {
   try {
     return json(verifyForMcp(original, candidate, profile_json));
+  } catch (error) {
+    return failure(error);
+  }
+});
+
+server.registerTool('hyv_verify_copy_spec', {
+  description: 'Verify a candidate against the existing voice gates and a local CopySpec. Immutable claims must remain verbatim and each carries local evidence; prohibited claims fail closed.',
+  inputSchema: { original: writing, candidate: writing, profile_json: profileJson, copy_spec_json: copySpecJson },
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+}, async ({ original, candidate, profile_json, copy_spec_json }) => {
+  try {
+    return json(verifyCopySpecForMcp(original, candidate, profile_json, copy_spec_json));
   } catch (error) {
     return failure(error);
   }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { analyzeForMcp, buildProfileForMcp, patternsForMcp, rewritePromptForMcp, verifyCopySpecForMcp, verifyForMcp } from './mcp-tools.js';
+import { analyzeForMcp, applyRewriteForMcp, buildProfileForMcp, patternsForMcp, prepareRewriteForMcp, rewritePromptForMcp, verifyCopySpecForMcp, verifyForMcp } from './mcp-tools.js';
 
 const writing = z.string().min(1).max(100_000);
 const profileJson = z.string().min(1).max(50_000);
@@ -50,6 +50,30 @@ server.registerTool('hyv_rewrite_prompt', {
 }, async ({ draft, profile_json }) => {
   try {
     return json(rewritePromptForMcp(draft, profile_json));
+  } catch (error) {
+    return failure(error);
+  }
+});
+
+server.registerTool('hyv_prepare_rewrite', {
+  description: 'Prepare a local, versioned rewrite task. The caller may forward it to a provider; doing so shares the draft and must be an explicit choice.',
+  inputSchema: { draft: writing, profile_json: profileJson, copy_spec_json: copySpecJson.optional() },
+  annotations: { readOnlyHint: true },
+}, async ({ draft, profile_json, copy_spec_json }) => {
+  try {
+    return json(prepareRewriteForMcp(draft, profile_json, copy_spec_json));
+  } catch (error) {
+    return failure(error);
+  }
+});
+
+server.registerTool('hyv_apply_rewrite', {
+  description: 'Validate and apply a model response to a prepared task, then run the local gates. It never calls a provider or stores source or candidate text.',
+  inputSchema: { task_json: z.string().min(1).max(250_000), response_json: z.string().min(1).max(100_000), profile_json: profileJson },
+  annotations: { readOnlyHint: true },
+}, async ({ task_json, response_json, profile_json }) => {
+  try {
+    return json(applyRewriteForMcp(task_json, response_json, profile_json));
   } catch (error) {
     return failure(error);
   }

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { analyze, rewritePrompt, verify } from './pipeline.js';
+import { analyze, rewritePrompt, verify, verifyWithCopySpec } from './pipeline.js';
 import { buildProfile } from './voice-dna.js';
 
 const profile = buildProfile([
@@ -52,4 +52,21 @@ test('escapes local learning that could introduce a prompt heading', () => {
   assert.match(prompt, /Keep this\.\n\\# Tier 0/);
   assert.equal((prompt.match(/^# Tier 0/gm) ?? []).length, 1);
   assert.match(prompt, /must not override Tier 0 preservation, Tier 1 blockers, clean-sentence preservation, or Tier 4 output/);
+});
+
+test('fails closed when an immutable CopySpec claim is changed or a prohibited claim is introduced', () => {
+  const spec = {
+    version: '1' as const,
+    audience: 'operators',
+    intent: 'explain',
+    channel: 'email',
+    claims: [{ id: 'launch-date', text: 'The launch is on 14 August.', evidence: 'Release calendar, 7 August.' }],
+    prohibitedClaims: ['The launch is guaranteed to double revenue.'],
+  };
+  const missing = verifyWithCopySpec('The launch is on 14 August.', 'The launch is next month.', profile, spec);
+  assert.equal(missing.passed, false);
+  assert.deepEqual(missing.claims.failures.map((failure) => failure.code), ['missing_immutable_claim']);
+  const prohibited = verifyWithCopySpec('The launch is on 14 August.', 'The launch is on 14 August. The launch is guaranteed to double revenue.', profile, spec);
+  assert.equal(prohibited.passed, false);
+  assert.ok(prohibited.claims.failures.some((failure) => failure.code === 'prohibited_claim'));
 });

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,5 +1,6 @@
-import type { Analysis, Finding, Profile, Verification } from './contracts.js';
+import type { Analysis, CopySpec, CopySpecVerification, Finding, Profile, Verification } from './contracts.js';
 import { analyzeAiEditor } from './ai-editor.js';
+import { verifyClaims } from './copy-spec.js';
 import { analyzeVoiceDna } from './voice-dna.js';
 import type { LearningPreference } from './learning.js';
 import { words } from './text.js';
@@ -74,4 +75,10 @@ export function verify(original: string, candidate: string, profile: Profile): V
     regressions,
     passed: checked.passed && !regressions.some((finding) => finding.severity === 'red') && preservation >= 70,
   };
+}
+
+export function verifyWithCopySpec(original: string, candidate: string, profile: Profile, spec: CopySpec): CopySpecVerification {
+  const verification = verify(original, candidate, profile);
+  const claims = verifyClaims(candidate, spec);
+  return { ...verification, claims, passed: verification.passed && claims.passed };
 }

--- a/src/rewrite-task.test.ts
+++ b/src/rewrite-task.test.ts
@@ -57,3 +57,11 @@ test('keeps a valid response byte-for-byte unchanged by repair adapters', () => 
   assert.equal(result.receipt.responseFingerprint.length, 64);
   assert.deepEqual(result.receipt.adapterIds, []);
 });
+
+test('repairs only an exact outer JSON code fence after JSON parsing fails', () => {
+  const task = prepareRewriteTask('I leverage the answer with useful detail and clear mechanism.', profile);
+  const response = `\`\`\`json\n${JSON.stringify({ version: '1', taskFingerprint: task.fingerprint, replacements: [{ sentenceId: 1, text: 'I use the answer with useful detail and clear mechanism.' }] })}\n\`\`\``;
+  const result = applyRewriteResponse(task, response);
+  assert.equal(result.status, 'accepted');
+  assert.deepEqual(result.receipt.adapterIds, ['fenced_json_v1']);
+});

--- a/src/rewrite-task.test.ts
+++ b/src/rewrite-task.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { applyRewriteResponse, prepareRewriteTask } from './rewrite-task.js';
+import { buildProfile } from './voice-dna.js';
+
+const profile = buildProfile([
+  'I write clear notes. I keep the mechanism visible.',
+  'I name the trade-off. Then I make the next step plain.',
+], ['leverage']);
+
+test('applies only eligible numbered replacements and preserves all clean bytes', () => {
+  const task = prepareRewriteTask('I leverage the answer. The launch is on 14 August.', profile);
+  const result = applyRewriteResponse(task, {
+    version: '1',
+    taskFingerprint: task.fingerprint,
+    replacements: [{ sentenceId: 1, text: 'I use the answer.' }],
+  });
+  assert.equal(result.status, 'accepted');
+  assert.equal(result.candidate, 'I use the answer. The launch is on 14 August.');
+  assert.deepEqual(result.receipt.adapterIds, []);
+});
+
+test('rejects a duplicate, unknown, or clean sentence replacement before it creates a candidate', () => {
+  const task = prepareRewriteTask('I leverage the answer. The launch is on 14 August.', profile);
+  const duplicate = applyRewriteResponse(task, JSON.stringify({
+    version: '1', taskFingerprint: task.fingerprint,
+    replacements: [{ sentenceId: 1, text: 'I use the answer.' }, { sentenceId: 1, text: 'I choose the answer.' }],
+  }));
+  assert.equal(duplicate.status, 'repairable');
+  assert.equal(duplicate.candidate, undefined);
+  assert.equal(duplicate.failures[0]?.code, 'duplicate_sentence_id');
+
+  const unknown = applyRewriteResponse(task, {
+    version: '1', taskFingerprint: task.fingerprint,
+    replacements: [{ sentenceId: 99, text: 'I use the answer.' }],
+  });
+  assert.equal(unknown.status, 'repairable');
+  assert.equal(unknown.failures[0]?.code, 'unknown_sentence_id');
+});
+
+test('repairs only a stringified replacement list after initial schema rejection', () => {
+  const task = prepareRewriteTask('I leverage the answer.', profile);
+  const result = applyRewriteResponse(task, JSON.stringify({
+    version: '1', taskFingerprint: task.fingerprint,
+    replacements: JSON.stringify([{ sentenceId: 1, text: 'I use the answer.' }]),
+  }));
+  assert.equal(result.status, 'accepted');
+  assert.equal(result.candidate, 'I use the answer.');
+  assert.deepEqual(result.receipt.adapterIds, ['stringified_replacements_v1']);
+});
+
+test('keeps a valid response byte-for-byte unchanged by repair adapters', () => {
+  const task = prepareRewriteTask('I leverage the answer.', profile);
+  const response = JSON.stringify({ version: '1', taskFingerprint: task.fingerprint, replacements: [{ sentenceId: 1, text: 'I use the answer.' }] });
+  const result = applyRewriteResponse(task, response);
+  assert.equal(result.status, 'accepted');
+  assert.equal(result.receipt.responseFingerprint.length, 64);
+  assert.deepEqual(result.receipt.adapterIds, []);
+});

--- a/src/rewrite-task.ts
+++ b/src/rewrite-task.ts
@@ -65,6 +65,12 @@ function repairStringifiedReplacements(value: unknown): { value: unknown; adapte
   }
 }
 
+function repairFencedJson(value: unknown): { value: unknown; adapterId?: string } {
+  if (typeof value !== 'string') return { value };
+  const match = value.match(/^```json\s*\n([\s\S]*?)\n```\s*$/i);
+  return match ? { value: match[1], adapterId: 'fenced_json_v1' } : { value };
+}
+
 export function prepareRewriteTask(draft: string, profile: Profile, copySpec?: CopySpec): RewriteTask {
   const analysis = rewritePrompt(draft, profile);
   const mapped = sentences(draft);
@@ -100,7 +106,8 @@ function rejected(task: RewriteTask, raw: unknown, failures: RewriteFailure[], a
 export function applyRewriteResponse(task: RewriteTask, raw: unknown): RewriteApplyResult {
   const source = typeof raw === 'string' ? parseJson(raw) : raw;
   const parsed = isFailure(source) ? source : parseResponse(source);
-  const repaired = isFailure(parsed) && parsed.code === 'invalid_response_shape' ? repairStringifiedReplacements(source) : { value: source };
+  const fenced = isFailure(parsed) && parsed.code === 'invalid_json' ? repairFencedJson(raw) : { value: source };
+  const repaired = isFailure(parsed) && parsed.code === 'invalid_response_shape' ? repairStringifiedReplacements(source) : fenced;
   const response = repaired.adapterId ? parseResponse(repaired.value) : parsed;
   const adapterIds = repaired.adapterId ? [repaired.adapterId] : [];
   if (isFailure(response)) return rejected(task, raw, [response], adapterIds);
@@ -130,5 +137,6 @@ export function evaluateRewriteResponse(task: RewriteTask, raw: unknown, profile
   const verification = task.copySpec
     ? verifyWithCopySpec(task.draft, applied.candidate, profile, task.copySpec)
     : verify(task.draft, applied.candidate, profile);
-  return verification.passed ? { ...applied, verification } : { ...applied, status: 'needs_escalation', verification };
+  if (!verification.passed) return { ...applied, status: 'needs_escalation', verification };
+  return { ...applied, status: 'needs_semantic_review', verification };
 }

--- a/src/rewrite-task.ts
+++ b/src/rewrite-task.ts
@@ -1,0 +1,134 @@
+import { createHash } from 'node:crypto';
+import type { CopySpec, Profile, RewriteApplyResult, RewriteEvaluation, RewriteFailure, RewriteReplacement, RewriteResponse, RewriteTask } from './contracts.js';
+import { rewritePrompt, verify, verifyWithCopySpec } from './pipeline.js';
+import { sentences } from './text.js';
+
+const MAX_RESPONSE_BYTES = 100_000;
+const MAX_REPLACEMENTS = 100;
+const MAX_REPLACEMENT_CHARACTERS = 10_000;
+
+function fingerprint(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function failure(code: RewriteFailure['code'], message: string, path?: string): RewriteFailure {
+  return { code, message, ...(path ? { path } : {}) };
+}
+
+function responseFingerprint(response: unknown): string {
+  return fingerprint(response);
+}
+
+function parseJson(value: string): unknown | RewriteFailure {
+  if (Buffer.byteLength(value) > MAX_RESPONSE_BYTES) return failure('response_too_large', `Response exceeds ${MAX_RESPONSE_BYTES} bytes.`);
+  try {
+    return JSON.parse(value);
+  } catch {
+    return failure('invalid_json', 'Response must be valid JSON.');
+  }
+}
+
+function isFailure(value: unknown): value is RewriteFailure {
+  return typeof value === 'object' && value !== null && 'code' in value;
+}
+
+function parseResponse(value: unknown): RewriteResponse | RewriteFailure {
+  const raw = typeof value === 'string' ? parseJson(value) : value;
+  if (isFailure(raw)) return raw;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return failure('invalid_response_shape', 'Response must be an object.');
+  const response = raw as Partial<RewriteResponse>;
+  if (response.version !== '1') return failure('invalid_response_version', 'Response version must be "1".', 'version');
+  if (typeof response.taskFingerprint !== 'string' || response.taskFingerprint.length !== 64) return failure('invalid_response_shape', 'Response must include the task fingerprint.', 'taskFingerprint');
+  if (!Array.isArray(response.replacements)) return failure('invalid_response_shape', 'Response replacements must be an array.', 'replacements');
+  if (response.replacements.length > MAX_REPLACEMENTS) return failure('invalid_response_shape', `Response may include at most ${MAX_REPLACEMENTS} replacements.`, 'replacements');
+  for (const [index, replacement] of response.replacements.entries()) {
+    if (!replacement || typeof replacement !== 'object' || Array.isArray(replacement) || !Number.isInteger((replacement as RewriteReplacement).sentenceId) || typeof (replacement as RewriteReplacement).text !== 'string') {
+      return failure('invalid_response_shape', 'Every replacement requires an integer sentenceId and string text.', `replacements[${index}]`);
+    }
+    if (!(replacement as RewriteReplacement).text.trim() || (replacement as RewriteReplacement).text.length > MAX_REPLACEMENT_CHARACTERS) {
+      return failure('invalid_replacement_text', `Replacement text must contain at most ${MAX_REPLACEMENT_CHARACTERS} characters.`, `replacements[${index}].text`);
+    }
+  }
+  return response as RewriteResponse;
+}
+
+function repairStringifiedReplacements(value: unknown): { value: unknown; adapterId?: string } {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return { value };
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.replacements !== 'string') return { value };
+  try {
+    const replacements = JSON.parse(raw.replacements);
+    if (!Array.isArray(replacements)) return { value };
+    return { value: { ...raw, replacements }, adapterId: 'stringified_replacements_v1' };
+  } catch {
+    return { value };
+  }
+}
+
+export function prepareRewriteTask(draft: string, profile: Profile, copySpec?: CopySpec): RewriteTask {
+  const analysis = rewritePrompt(draft, profile);
+  const mapped = sentences(draft);
+  const eligibleSentenceIds = new Set([
+    ...analysis.matchAll(/^- Sentence (\d+) \[/gm),
+  ].map((match) => Number(match[1])));
+  const taskBase = {
+    version: '1' as const,
+    draft,
+    sentences: mapped.map((sentence) => ({ id: sentence.index, text: sentence.text, eligible: eligibleSentenceIds.has(sentence.index) })),
+    eligibleSentenceIds: [...eligibleSentenceIds].sort((left, right) => left - right),
+    prompt: analysis,
+    ...(copySpec ? { copySpec } : {}),
+  };
+  return { ...taskBase, fingerprint: fingerprint(taskBase) };
+}
+
+export function parseRewriteTask(value: unknown): RewriteTask {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Rewrite task must be an object.');
+  const task = value as Partial<RewriteTask>;
+  if (task.version !== '1' || typeof task.fingerprint !== 'string' || typeof task.draft !== 'string' || typeof task.prompt !== 'string' || !Array.isArray(task.sentences) || !Array.isArray(task.eligibleSentenceIds)) {
+    throw new Error('Rewrite task does not match version 1.');
+  }
+  const { fingerprint: suppliedFingerprint, ...base } = task;
+  if (fingerprint(base) !== suppliedFingerprint) throw new Error('Rewrite task fingerprint does not match its contents.');
+  return task as RewriteTask;
+}
+
+function rejected(task: RewriteTask, raw: unknown, failures: RewriteFailure[], adapterIds: string[] = []): RewriteApplyResult {
+  return { status: 'repairable', failures, receipt: { version: '1', taskFingerprint: task.fingerprint, responseFingerprint: responseFingerprint(raw), adapterIds } };
+}
+
+export function applyRewriteResponse(task: RewriteTask, raw: unknown): RewriteApplyResult {
+  const source = typeof raw === 'string' ? parseJson(raw) : raw;
+  const parsed = isFailure(source) ? source : parseResponse(source);
+  const repaired = isFailure(parsed) && parsed.code === 'invalid_response_shape' ? repairStringifiedReplacements(source) : { value: source };
+  const response = repaired.adapterId ? parseResponse(repaired.value) : parsed;
+  const adapterIds = repaired.adapterId ? [repaired.adapterId] : [];
+  if (isFailure(response)) return rejected(task, raw, [response], adapterIds);
+  if (response.taskFingerprint !== task.fingerprint) return rejected(task, raw, [failure('task_fingerprint_mismatch', 'Response task fingerprint does not match this task.', 'taskFingerprint')], adapterIds);
+  const seen = new Set<number>();
+  const sentenceMap = new Map(task.sentences.map((sentence) => [sentence.id, sentence]));
+  for (const [index, replacement] of response.replacements.entries()) {
+    if (seen.has(replacement.sentenceId)) return rejected(task, raw, [failure('duplicate_sentence_id', 'Each sentence may be replaced once.', `replacements[${index}].sentenceId`)], adapterIds);
+    seen.add(replacement.sentenceId);
+    const sentence = sentenceMap.get(replacement.sentenceId);
+    if (!sentence) return rejected(task, raw, [failure('unknown_sentence_id', 'Replacement sentenceId is not in this task.', `replacements[${index}].sentenceId`)], adapterIds);
+    if (!sentence.eligible) return rejected(task, raw, [failure('ineligible_sentence_id', 'Only flagged sentences may be replaced.', `replacements[${index}].sentenceId`)], adapterIds);
+  }
+  const sourceSentences = sentences(task.draft);
+  const replacements = new Map(response.replacements.map((replacement) => [replacement.sentenceId, replacement.text.trim()]));
+  let candidate = task.draft;
+  for (const sentence of [...sourceSentences].reverse()) {
+    const replacement = replacements.get(sentence.index);
+    if (replacement !== undefined) candidate = `${candidate.slice(0, sentence.start)}${replacement}${candidate.slice(sentence.end)}`;
+  }
+  return { status: 'accepted', candidate, failures: [], receipt: { version: '1', taskFingerprint: task.fingerprint, responseFingerprint: responseFingerprint(raw), adapterIds } };
+}
+
+export function evaluateRewriteResponse(task: RewriteTask, raw: unknown, profile: Profile): RewriteEvaluation {
+  const applied = applyRewriteResponse(task, raw);
+  if (applied.status !== 'accepted' || !applied.candidate) return applied;
+  const verification = task.copySpec
+    ? verifyWithCopySpec(task.draft, applied.candidate, profile, task.copySpec)
+    : verify(task.draft, applied.candidate, profile);
+  return verification.passed ? { ...applied, verification } : { ...applied, status: 'needs_escalation', verification };
+}

--- a/src/semantic-review.test.ts
+++ b/src/semantic-review.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseSemanticVerdict, reviewSemanticVerdicts } from './semantic-review.js';
+
+test('accepts only three independent clean semantic verdicts', () => {
+  const result = reviewSemanticVerdicts(['deepseek', 'kimi', 'sonnet'].map((evaluatorId) => parseSemanticVerdict(evaluatorId, { approved: true, violations: [] })));
+  assert.equal(result.status, 'accepted');
+});
+
+test('escalates disagreement and action drift', () => {
+  const disagreement = reviewSemanticVerdicts([
+    parseSemanticVerdict('deepseek', { approved: true, violations: [] }),
+    parseSemanticVerdict('kimi', { approved: false, violations: ['action_change'] }),
+    parseSemanticVerdict('sonnet', { approved: false, violations: ['action_change'] }),
+  ]);
+  assert.equal(disagreement.reason, 'evaluator_disagreement');
+  const rejected = reviewSemanticVerdicts(['deepseek', 'kimi', 'sonnet'].map((evaluatorId) => parseSemanticVerdict(evaluatorId, { approved: false, violations: ['action_change'] })));
+  assert.equal(rejected.reason, 'semantic_violation');
+});

--- a/src/semantic-review.ts
+++ b/src/semantic-review.ts
@@ -1,0 +1,20 @@
+import type { SemanticReview, SemanticVerdict, SemanticViolation } from './contracts.js';
+
+const violations = new Set<SemanticViolation>(['action_change', 'dropped_object', 'unsupported_claim', 'constraint_weakened', 'clarity_regression']);
+
+export function parseSemanticVerdict(evaluatorId: string, value: unknown): SemanticVerdict {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Semantic evaluator response must be an object.');
+  const verdict = value as Partial<SemanticVerdict>;
+  if (typeof verdict.approved !== 'boolean' || !Array.isArray(verdict.violations) || !verdict.violations.every((item) => typeof item === 'string' && violations.has(item as SemanticViolation))) {
+    throw new Error('Semantic evaluator response must include approved and known violations.');
+  }
+  return { evaluatorId, approved: verdict.approved, violations: verdict.violations as SemanticViolation[] };
+}
+
+export function reviewSemanticVerdicts(verdicts: SemanticVerdict[]): SemanticReview {
+  const ids = new Set(verdicts.map((verdict) => verdict.evaluatorId));
+  if (verdicts.length !== 3 || ids.size !== 3) return { status: 'needs_escalation', verdicts, reason: 'insufficient_evaluators' };
+  if (verdicts.every((verdict) => verdict.approved && verdict.violations.length === 0)) return { status: 'accepted', verdicts };
+  if (verdicts.some((verdict) => verdict.approved)) return { status: 'needs_escalation', verdicts, reason: 'evaluator_disagreement' };
+  return { status: 'needs_escalation', verdicts, reason: 'semantic_violation' };
+}


### PR DESCRIPTION
## Summary

HYV can now turn an external model response into a constrained rewrite candidate without trusting the model to preserve the rest of the draft. The route rejects unauthorized sentence changes and stops at semantic review until three independent, schema-valid evaluators unanimously find no action, object, claim, constraint, or clarity drift.

## Design decisions

- Keep model invocation outside the package. CLI and MCP prepare and apply the same local task contract; neither adds a provider credential or a runtime network path.
- Make CopySpec the narrow factual plane. Declared immutable and prohibited claims are hard gates, while semantic review handles fluent meaning drift that lexical preservation cannot see.
- Validate before repairing. The only adapters are recorded, bounded response-shape repairs: a stringified replacement list and an exact outer JSON code fence.
- Route uncertainty to escalation. Deterministic gate passes become `needs_semantic_review`; evaluator disagreement or any named violation becomes `needs_escalation`.

## Validation

- `npm test` — 53 passing tests, covering task fingerprints, eligible sentence boundaries, malformed responses, both repair adapters, CLI/MCP parity, and unanimous semantic-review routing.
- `npm run check:release` — passed.
- Synthetic Command Code trial: six candidate models were checked against the same constrained packet. Three independent evaluators accepted only the faithful Kimi rewrite; all other candidates were rejected for action/object drift or unsupported meaning changes.
- Opus 4.7 could not be run in the available Command Code plan, so this PR makes no Opus comparison claim.

## Post-Deploy Monitoring & Validation

No production monitoring is required: this is local CLI/MCP plumbing with no deployed runtime or network service. Before recommending a lower-tier route, run the committed benchmark protocol on the locked, rights-cleared partition and record evaluator disagreement, escalation rate, factual failures, and all-in cost.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
