### PR TITLE
feat(benchmark): emit a blocked Stage 1 human-study operator kit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 *.local
 mcpb/server/
 *.mcpb
+.worktrees/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -12,7 +12,7 @@ The private lane is disabled by default and must stay outside every repository a
 
 ## Stage 1 checkpoint setup
 
-MAR-362 pins the unchanged baseline to `4e6269121d551c008a34db73077e1e4fea41b3f9` and the Stage 1 candidate to `550ea24f652291dca13757fdbd2f0fa0b5e3f621`. The evaluator validates captured JSON and NDJSON but never calls a provider.
+MAR-362 pins the unchanged, checkoutable baseline to `4e6269121d551c008a34db73077e1e4fea41b3f9`. The hardcoded `STAGE1_COMMIT` is `550ea24f652291dca13757fdbd2f0fa0b5e3f621`; it is not retrievable from origin after the PR #27 squash merge. The merged head is `32d35eb35246696f0a56e7732d714ca6c22060f7`. No committed locked-human protocol digest exists. Do not create one until a rights-approved non-synthetic corpus and the rest of the protocol inputs are available. The evaluator validates captured JSON and NDJSON but never calls a provider.
 
 Run the synthetic calibration packet outside the repository:
 
@@ -21,6 +21,14 @@ npm run stage1:dry-run -- --out /absolute/path/outside-the-repository/stage1-dry
 ```
 
 The expected result is `BLOCKED`, `promotable: false`, with `human_writer_evidence_deferred`, `synthetic_fixture_evidence`, and `locked_human_evidence_required`. This checks the protocol, run, blind mapping, reviewer log, ratings seal, report, and release-audit bindings. It is development evidence only.
+
+Emit the human-study operator kit outside the repository and every worktree:
+
+```bash
+npm run stage1:human-packet -- --out /absolute/path/outside-the-repository/stage1-human-packet
+```
+
+This kit does not pass MAR-362. The automated harness is not human evidence. `hyv_score` and ratings produced by a model or agent are not writer evidence. Kit `--out` is emit-only and is not approved encrypted custody. Do not capture the Stage 1 arm until `STAGE1_COMMIT` is checkoutable; do not label merged-HEAD bytes as that commit. Shape-checked receipts remain unverified until an external verifier exists.
 
 The lower-level commands operate on the emitted artifacts:
 
@@ -32,8 +40,10 @@ npm run stage1:evaluate -- freeze-blind --protocol <protocol.json> --runs <runs>
 npm run stage1:evaluate -- record-rating --packet <packet.json> --ratings <ratings.ndjson> --rating <signed-rating.json>
 npm run stage1:evaluate -- seal-ratings --packet <packet.json> --mapping <mapping.json> --ratings <ratings.ndjson>
 npm run stage1:evaluate -- reduce --protocol <protocol.json> --runs <runs> --packet <packet.json> --mapping <mapping.json> --ratings <ratings.ndjson> --seal <seal.json> --release-audit <audit.json>
-npm run stage1:evaluate -- record-checkpoint-disposition --report <report.json> --disposition <PROCEED_TO_MAR_363|STOP|REPEAT_PROTOCOL> --attestation <external-receipt.json>
+npm run stage1:evaluate -- record-checkpoint-disposition --report <report.json> --disposition <STOP|REPEAT_PROTOCOL> --attestation <external-receipt.json>
 ```
+
+While `human_writer_evidence_deferred` is forced, the report decision is `BLOCKED` and `PASS` is unreachable. The only accepted checkpoint dispositions are `STOP` and `REPEAT_PROTOCOL`. `PROCEED_TO_MAR_363` is rejected with `human_evidence_deferred`.
 
 Before the locked partition runs, commit the canonical protocol digest. It freezes corpus and per-case provenance/rights digests, provider/model/revision/settings, task/ruleset/rubric digests, randomization commitment, statistic, margin, sample and rating minima, missingness, tie, retry and routing policies, disclosure and derived-retention scopes, and the release-audit contract. No field may be filled from observed results.
 
@@ -60,10 +70,10 @@ Promotion requires the committed confidence method, sample/rating minimums, revi
 Automation stops before locked evidence. A locked run still needs:
 
 1. A rights-approved, non-synthetic corpus with per-case provenance and provider/reviewer disclosure permission.
-2. An approved encrypted root, custodian, retention/deletion plan, mapping custodian, reviewer roster, and trusted external signing keys.
+2. Approved encrypted custody, a retention/deletion plan, a mapping custodian, a reviewer roster, and trusted external signing keys.
 3. Pre-registered model revision, route, statistic, margin, sample/rating minimums, missingness, tie, retry, and routing policies.
-4. Real provider captures and blind human ratings with externally verified receipts.
-5. A human Stage 1 checkpoint disposition after the bound release audit.
+4. Real provider captures and blind human ratings with external receipts.
+5. A mapping-custody attestation and a human checkpoint disposition after the bound release audit.
 
 Synthetic fixtures, model-generated ballots, unsigned records, missing assignments, or digest drift can never produce `PROCEED_TO_MAR_363`.
 The current harness rejects `PROCEED_TO_MAR_363` unconditionally. MAR-362 stays open until the external verifier and reviewer-roster check are implemented and the real writer study is complete.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,17 +1,24 @@
 # Benchmarks and historical results
 
-The Hold Your Voice vs GPT-5.6 article reported a historical pilot of 16 matched draft pairs, 29 of 32 blind reviewer preferences for the profile-aware treatment, and a +0.34 five-point voice-composite change. It remains a public product report because this repository lacks the raw tasks, outputs, reviewer records, model settings, and rights manifest needed to reproduce it.
-
-Treat those numbers as historical context rather than a leaderboard claim. A reproducible benchmark must publish author-owned or synthetic task packets, baseline and treatment outputs, model identifiers/settings, randomized review protocol, per-engine reports, human/factual rubrics, and a provenance/license field for every case. Keep deterministic fixture tests separate from any credentialed model runner.
+Historical articles are not checkpoint evidence because this repository lacks the raw tasks, outputs, reviewer records, model settings, and rights manifest needed to reproduce them. A reproducible benchmark must publish author-owned or synthetic task packets, baseline and treatment outputs, model identifiers/settings, randomized review protocol, per-engine reports, human/factual rubrics, and a provenance/license field for every case. Keep deterministic fixture tests separate from any credentialed model runner.
 
 ## Stage 1 evidence gate
 
-The Stage 1 setup freezes Hyv 3.2.0 at `4e6269121d551c008a34db73077e1e4fea41b3f9` and the completed Stage 1 lifecycle at `550ea24f652291dca13757fdbd2f0fa0b5e3f621`. Versioned schemas under `benchmarks/schema/` cover the immutable protocol, status-discriminated run events, encrypted blind packet, sealed A/B mapping, append-only reviewer records, ratings seal, aggregate report, and checkpoint disposition.
+The Stage 1 setup freezes the checkoutable baseline at `4e6269121d551c008a34db73077e1e4fea41b3f9`. The hardcoded `STAGE1_COMMIT` is `550ea24f652291dca13757fdbd2f0fa0b5e3f621`; it is not retrievable from origin after the PR #27 squash merge. The merged head is `32d35eb35246696f0a56e7732d714ca6c22060f7`. No committed locked-human protocol digest exists. Versioned schemas under `benchmarks/schema/` cover the immutable protocol, status-discriminated run events, encrypted blind packet, sealed A/B mapping, append-only reviewer records, ratings seal, aggregate report, and checkpoint disposition.
 
 Every locked assignment stays in the intent-to-treat denominator. Timeouts, abandonment, and hard-gate failures are failures; they are never silently rerun or converted into preference ballots. Reports reconcile planned, completed, missing, failed, timed-out, and abandoned assignments and bind every artifact through canonical SHA-256 digests. Synthetic development and calibration fixtures always reduce to `BLOCKED` and cannot support a promotion claim.
 
-Human evidence is external to automation. Private source and blind candidates stay in an approved encrypted root. Exported artifacts contain digests and categorical ratings only. Reviewer, mapping-custody, and checkpoint receipts must come from an external verifier. The current evaluator validates receipt shape and artifact bindings but deliberately blocks cryptographic trust and reviewer-roster acceptance until that verifier is configured.
+Human evidence is external to automation. Remaining inputs are a rights-approved non-synthetic corpus, encrypted custody, a reviewer roster, trust keys, provider captures, blind ratings with external receipts, a mapping-custody attestation, and a checkpoint disposition. Private source and blind candidates stay in approved encrypted custody. Exported artifacts contain digests and categorical ratings only. The current evaluator validates receipt shape and artifact bindings but deliberately blocks cryptographic trust and reviewer-roster acceptance until an external verifier is configured.
 
-Run `npm run stage1:dry-run -- --out <absolute-path-outside-the-repository>` to exercise the automatable packet. See `benchmarks/README.md` for the locked-run commands and remaining human inputs.
+Run the automated dry-run and emit the human-study kit outside the repository:
+
+```bash
+npm run stage1:dry-run -- --out /absolute/path/outside-the-repository/stage1-dry-run
+npm run stage1:human-packet -- --out /absolute/path/outside-the-repository/stage1-human-packet
+```
+
+The kit does not pass MAR-362. The automated harness is not human evidence. `hyv_score` and ratings produced by a model or agent are not writer evidence. Kit `--out` is emit-only and is not approved encrypted custody. Do not capture the Stage 1 arm until `STAGE1_COMMIT` is checkoutable; do not label merged-HEAD bytes as that commit. Shape-checked receipts remain unverified until an external verifier exists. While `human_writer_evidence_deferred` is forced, the report decision is `BLOCKED` and `PASS` is unreachable. A disposition may be only `STOP` or `REPEAT_PROTOCOL`; `PROCEED_TO_MAR_363` is rejected with `human_evidence_deferred`.
+
+See `benchmarks/README.md` for the locked-run commands.
 
 See the historical sources: https://holdyourvoice.com/blog/voice-memory-composer and https://holdyourvoice.com/blog/hold-your-voice-vs-gpt-5-6-writing.

--- a/docs/plans/2026-08-13-1627-feat-stage1-human-study-packet-plan.md
+++ b/docs/plans/2026-08-13-1627-feat-stage1-human-study-packet-plan.md
@@ -1,0 +1,200 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+title: "feat: Add Stage 1 human-study packet"
+type: feat
+date: 2026-08-13
+---
+
+# feat: Add Stage 1 human-study packet
+
+## Goal Capsule
+
+- **Objective:** Ship a runnable operator packet so humans can collect MAR-362 writer evidence against the locked Stage 1 protocol, without claiming a checkpoint pass.
+- **Authority:** Live Linear MAR-362 acceptance contract. Runtime contracts in `src/stage1-evaluation.ts` and `benchmarks/schema/` beat README prose. PR #27 merge `32d35eb35246696f0a56e7732d714ca6c22060f7` is the working head.
+- **Execution profile:** Proof-first. Emit templates and commands only. Never mint writer ratings, reviewer IDs, or attestations presented as real.
+- **Stop conditions:** Stop if the packet would write private prose into git, call a provider, rebind `STAGE1_COMMIT`, allow `PROCEED_TO_MAR_363`, or mark MAR-362 Done.
+- **Tail ownership:** Local tests, release audit, and a PR. No merge, tag, or publication.
+
+## Product Contract
+
+### Summary
+
+Operators need one outside-repo kit that names the locked identities, remaining human inputs, and exact validation commands. The current harness stays fail-closed. Agent or model scores are not writer evidence.
+
+### Problem Frame
+
+Stage 1 merged with a synthetic dry-run that always returns `BLOCKED`. There is no operator kit for locked-human collection. `STAGE1_COMMIT` `550ea24f652291dca13757fdbd2f0fa0b5e3f621` is hardcoded and is not on origin after the PR #27 squash merge. MAR-363 remains blocked.
+
+### Key Decisions
+
+- Keep MAR-362 unpassed until live Linear contains a real writer study that the repository validates. `(session-settled: user-directed — chosen over agent-generated pass: MAR-362 forbids synthetic or self-asserted evidence)`
+- Do not start MAR-363, MAR-364, or MAR-365. `(session-settled: user-directed — chosen over continuing the advanced rewrite: the gate has not passed)`
+- Agents may prepare packets and validate imported records; they may not create writer evidence. `(session-settled: user-directed — chosen over substituting model ratings: listed non-evidence includes agent preferences and model-generated ratings)`
+
+Governs R1, R2, R3, R8.
+
+### Requirements
+
+- R1. The packet must run from the repo and write only to an absolute path outside every worktree.
+- R2. The packet must print exact identities: baseline `4e6269121d551c008a34db73077e1e4fea41b3f9`, protocol `STAGE1_COMMIT` `550ea24f652291dca13757fdbd2f0fa0b5e3f621` plus whether that object is checkoutable, and current HEAD.
+- R3. The packet must include rights, provenance, reviewer-roster, trust-key, provider-capture, blind, correction-versus-confirm, completion, abandonment, missing-rating, intent-to-treat, and external-verification procedures that match runtime contracts.
+- R4. The packet must list exact `npm run stage1:evaluate` commands for commit-protocol through record-checkpoint-disposition.
+- R5. Decision rules must match the wire: report `BLOCKED` only today; disposition `STOP` or `REPEAT_PROTOCOL`; `PROCEED_TO_MAR_363` rejected; `PASS` unreachable while `human_writer_evidence_deferred` is forced.
+- R6. Empty roster, key, receipt, and ratings slots must be unfilled. The script must refuse to fabricate human ballots.
+- R7. Existing dry-run, evaluator, schemas, and fail-closed reducer must stay unchanged.
+- R8. Public docs must say there is no committed locked-human protocol digest until a rights-approved non-synthetic corpus exists.
+
+### Actors
+
+- A1. Maintainer operator who forwards provider calls outside Hyv.
+- A2. Mapping custodian, distinct from reviewers.
+- A3. Human reviewers with external signing keys.
+- A4. External verifier (not implemented; receipts are shape-checked only).
+
+### Key Flows
+
+- F1. Emit kit outside repo → operator fills private corpus and rights → commit protocol → paired capture → freeze blind → record ratings → seal → reduce → STOP or REPEAT_PROTOCOL.
+- F2. Any synthetic, unsigned, incomplete, leaked-label, or in-repo path fails closed and leaves MAR-362 unpassed.
+
+### Acceptance Examples
+
+- AE1. `npm run stage1:human-packet -- --out /tmp/hyv-human-packet` writes the kit, reports `BLOCKED`, and does not write ratings.
+- AE2. The same command with an in-repo `--out` exits non-zero.
+- AE3. Passing a fabricated human ratings file is refused.
+- AE4. Kit identities include checkoutable baseline, uncheckoutable `STAGE1_COMMIT`, and HEAD `32d35eb35246696f0a56e7732d714ca6c22060f7` when run from that head.
+- AE5. Docs state that `hyv_score` or any model score is not MAR-362 evidence.
+
+### Scope Boundaries
+
+**In scope:** operator kit script, tests, docs, package script, release-audit allowlist.
+
+**Out of scope:** cryptographic verifier, reviewer-roster membership check, rebinding `STAGE1_COMMIT`, MAR-363+ code, marking MAR-362 Done, provider calls, private corpus in git.
+
+**Deferred to follow-up work:** external verifier implementation; retrievable Stage 1 tree authorization; real writer study.
+
+### Success Criteria
+
+- Operators can run one command and follow the kit without inventing schema fields.
+- MAR-362 remains In Progress and unpassed.
+- Tests prove BLOCKED, outside-repo, and no fabricated human ballots.
+
+## Planning Contract
+
+### Assumptions
+
+- Inferred: keep `STAGE1_COMMIT` as the locked string and document that origin cannot check it out, rather than rebinding it to `32d35eb` or `69add5e`.
+- Inferred: do not implement cryptographic verification in this PR; document that `validateAttestation` is shape-plus-binding only.
+- Inferred: user request to "use a subagent instead of human verification" and "5.6 terra to score" applies to CE review of this packet, not to MAR-362 writer evidence.
+- No locked-human protocol digest exists yet; the kit must say `null` rather than invent one.
+
+### Key Technical Decisions
+
+- KTD1. Add `scripts/run-stage1-human-packet.mjs` modeled on `scripts/run-stage1-dry-run.mjs` (`--out` outside repo, mode `0o700`, `wx` writes). Do not extend the synthetic dry-run to emit human ratings.
+- KTD2. Keep `src/stage1-evaluation.ts` fail-closed. Do not remove `human_writer_evidence_deferred` or allow `PROCEED_TO_MAR_363`.
+- KTD3. Protocol JSON in the kit is a locked-human skeleton with empty `cases` omitted or marked incomplete so `commitProtocol` is not called until the operator supplies rights-approved cases.
+- KTD4. Runnable Stage 1 arm for operators is HEAD (or `origin/mar-366-stage1-release` at `b7c3f53` / `69add5e`). Protocol `stage1.sourceCommit` remains `550ea24…`. The kit must call out that release-audit binding is a string match, not `git cat-file`.
+- KTD5. Mapping custodian, reviewers, and unblinding access are distinct slots. `freezeBlind` does not encrypt; `encryptedAtRest` is a required boolean the operator must make true in approved storage.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TD
+  emit[Emit kit outside repo]
+  rights[Operator rights corpus]
+  commit[commit-protocol]
+  capture[Paired provider capture outside Hyv]
+  runs[validate-runs]
+  blind[freeze-blind]
+  rate[record-rating]
+  seal[seal-ratings]
+  reduce[reduce]
+  disp[STOP or REPEAT_PROTOCOL]
+  blocked[Always BLOCKED today]
+  emit --> rights --> commit --> capture --> runs --> blind --> rate --> seal --> reduce --> blocked
+  blocked --> disp
+  proceed[PROCEED_TO_MAR_363]
+  reduce -.->|rejected| proceed
+```
+
+### Implementation Constraints
+
+- Follow `scripts/run-stage1-dry-run.mjs` and `src/stage1-dry-run.test.ts`.
+- Digests use `sha256Canonical` except blind candidate bytes, which use UTF-8 SHA-256.
+- Errors for private paths stay text-free.
+- No founder or client prose.
+
+### Sequencing
+
+U1 script and kit files, then U2 tests, then U3 docs and release-audit wiring.
+
+## Implementation Units
+
+### U1. Emit the outside-repo human-study kit
+
+**Goal:** One command writes the operator kit and identity report without human evidence.
+**Requirements:** R1, R2, R3, R4, R5, R6, R8
+**Dependencies:** none
+**Files:** `scripts/run-stage1-human-packet.mjs`, `package.json`
+**Approach:**
+1. Mirror dry-run path hygiene: resolve `--out`, refuse repo or symlink-into-repo destinations.
+2. Write `IDENTITIES.json`, `OPERATOR.md`, `COMMANDS.sh`, `protocol-skeleton.json`, example slots for roster, rights, trust keys, mapping, ratings, and `status.json` with `decision: BLOCKED`, `promotable: false`, `lockedHumanProtocolDigest: null`, `stage1CommitCheckoutable: false` when `git cat-file` fails.
+3. Do not call `recordRating` with `evidenceClass: human`.
+**Execution note:** Start from a failing test that the command does not exist.
+**Patterns to follow:** `scripts/run-stage1-dry-run.mjs`
+**Test scenarios:** covered in U2
+**Verification:** Kit appears only under `--out`. stdout JSON matches `status.json` decision fields.
+
+### U2. Proof-first packet tests
+
+**Goal:** Prove outside-repo, BLOCKED, identity gap, and refusal to fabricate human ballots.
+**Requirements:** R1, R2, R6, R7
+**Dependencies:** U1
+**Files:** `src/stage1-human-packet.test.ts`
+**Approach:** Copy `src/stage1-dry-run.test.ts` structure. Add identity and fabrication-refusal cases.
+**Execution note:** Observe red failures before adding the script if the script is not yet present; otherwise keep tests as the contract.
+**Patterns to follow:** `src/stage1-dry-run.test.ts`
+**Test scenarios:**
+- Happy path: outside-repo `--out` returns `BLOCKED`, `promotable: false`, blockers include `human_writer_evidence_deferred` and `locked_human_evidence_required`, and no `ratings.ndjson` human ballots are written.
+- Edge: `IDENTITIES.json` reports baseline object exists, `STAGE1_COMMIT` missing, HEAD recorded.
+- Error: in-repo `--out` throws.
+- Error: symlink ancestor into the repository throws.
+- Error: `--fabricate-human-ratings` or equivalent is rejected if offered; if not offered, writing a human rating file is absent.
+- Integration: existing `stage1-dry-run` tests still pass.
+**Verification:** `node --test dist/stage1-human-packet.test.js` passes after build.
+
+### U3. Document commands and wire release audit
+
+**Goal:** Docs and release audit match the new script without claiming a pass.
+**Requirements:** R3, R4, R5, R8
+**Dependencies:** U1
+**Files:** `benchmarks/README.md`, `docs/BENCHMARKS.md`, `docs/wiki/Benchmarks-and-Research.md`, `scripts/release-audit.mjs`, `src/release-audit.test.ts`, `.gitignore`
+**Approach:**
+1. Add `stage1:human-packet` next to the dry-run commands.
+2. Replace any implication that `PROCEED_TO_MAR_363` is currently recordable with the runtime rejection.
+3. Allowlist the new script in `stage1CheckpointFiles` and `stage1Scripts`.
+4. Ignore `.worktrees/`.
+**Patterns to follow:** current Stage 1 sections in `benchmarks/README.md` and `scripts/release-audit.mjs`
+**Test scenarios:**
+- Release audit fails if `stage1:human-packet` is missing from `package.json`.
+- Release audit fails if `scripts/run-stage1-human-packet.mjs` is missing.
+- Docs name PASS as unreachable, BLOCKED as current report, REPEAT as `REPEAT_PROTOCOL`, STOP as `STOP`.
+**Verification:** `npm run check:release` passes. `git diff --check` clean.
+
+## Verification Contract
+
+- `npm test`
+- `npm run check:release`
+- `npm pack --dry-run --json` with a temp npm cache
+- `git diff --check`
+- Focused: `node --test dist/stage1-human-packet.test.js dist/stage1-dry-run.test.js dist/stage1-evaluation.test.js dist/release-audit.test.js`
+
+## Definition of Done
+
+- U1–U3 landed in `feat/mar-362-human-study-packet`.
+- No human ratings, secrets, or private prose in git.
+- MAR-362 stays In Progress and unpassed in Linear, with an evidence comment naming the commit.
+- PR states what was implemented, what was verified, and that writer evidence remains gated.
+- Abandoned experimental files are deleted.

--- a/docs/wiki/Benchmarks-and-Research.md
+++ b/docs/wiki/Benchmarks-and-Research.md
@@ -1,5 +1,20 @@
 # benchmarks and research
 
-the project may link to the public Voice Memory Composer and Hold Your Voice versus GPT-5.6 articles. treat them as dated historical reference material rather than a live leaderboard or universal performance claim.
+the project may link to historical articles, but they are not checkpoint evidence. a reproducible benchmark needs a rights-cleared corpus, frozen tasks, exact model and editor settings, a published rubric, separate evaluation dimensions, failure cases, and limitations.
 
-a reproducible benchmark needs a rights-cleared corpus, frozen tasks, exact model and editor settings, a published rubric, separate VoiceDNA-fit, AI-pattern-residue, factual-preservation, and human-preference dimensions, plus failure cases and limitations.
+## stage 1 human-study gate
+
+the checkoutable baseline is `4e6269121d551c008a34db73077e1e4fea41b3f9`. the hardcoded `STAGE1_COMMIT` is `550ea24f652291dca13757fdbd2f0fa0b5e3f621`; it is not retrievable from origin after the PR #27 squash merge. the merged head is `32d35eb35246696f0a56e7732d714ca6c22060f7`. no committed locked-human protocol digest exists.
+
+run both packets outside the repository:
+
+```bash
+npm run stage1:dry-run -- --out /absolute/path/outside-the-repository/stage1-dry-run
+npm run stage1:human-packet -- --out /absolute/path/outside-the-repository/stage1-human-packet
+```
+
+the human-study kit does not pass MAR-362. the automated harness is not human evidence. `hyv_score` and ratings produced by a model or agent are not writer evidence. kit `--out` is emit-only, not approved encrypted custody. do not capture the Stage 1 arm until `STAGE1_COMMIT` is checkoutable, and do not label merged-HEAD bytes as that commit. shape-checked receipts remain unverified.
+
+while `human_writer_evidence_deferred` is forced, the report decision is `BLOCKED` and `PASS` is unreachable. the only dispositions are `STOP` and `REPEAT_PROTOCOL`. `PROCEED_TO_MAR_363` is rejected with `human_evidence_deferred`.
+
+remaining human inputs are a rights-approved non-synthetic corpus, encrypted custody, a reviewer roster, trust keys, provider captures, blind ratings with external receipts, a mapping-custody attestation, and a checkpoint disposition.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "bin": { "hyv": "dist/cli.js" },
   "files": ["dist", "Readme.md", "LICENSE"],
-  "scripts": { "build": "tsc -p tsconfig.json", "bundle:claude": "esbuild src/mcp.ts --bundle --platform=node --format=esm --target=node20 --outfile=mcpb/server/index.js", "build:claude": "npm run build && npm run bundle:claude", "pack:claude": "npm run build:claude && node scripts/pack-claude.mjs", "stage1:evaluate": "node scripts/evaluate-rewrite-benchmark.mjs", "stage1:dry-run": "npm run build && node scripts/run-stage1-dry-run.mjs", "test": "npm run build && node --test dist/**/*.test.js", "check:release": "node scripts/release-audit.mjs", "prepack": "npm run check:release && npm test" },
+  "scripts": { "build": "tsc -p tsconfig.json", "bundle:claude": "esbuild src/mcp.ts --bundle --platform=node --format=esm --target=node20 --outfile=mcpb/server/index.js", "build:claude": "npm run build && npm run bundle:claude", "pack:claude": "npm run build:claude && node scripts/pack-claude.mjs", "stage1:evaluate": "node scripts/evaluate-rewrite-benchmark.mjs", "stage1:dry-run": "npm run build && node scripts/run-stage1-dry-run.mjs", "stage1:human-packet": "npm run build && node scripts/run-stage1-human-packet.mjs", "test": "npm run build && node --test dist/**/*.test.js", "check:release": "node scripts/release-audit.mjs", "prepack": "npm run check:release && npm test" },
   "engines": { "node": ">=20" },
   "license": "MIT",
   "keywords": ["ai-writing", "cli", "editing", "voice", "writing"],

--- a/scripts/release-audit.mjs
+++ b/scripts/release-audit.mjs
@@ -15,6 +15,7 @@ const stage1CheckpointFiles = [
   'src/stage1-evaluation.ts',
   'scripts/evaluate-rewrite-benchmark.mjs',
   'scripts/run-stage1-dry-run.mjs',
+  'scripts/run-stage1-human-packet.mjs',
   'benchmarks/schema/protocol-manifest.v1.schema.json',
   'benchmarks/schema/run-event.v1.schema.json',
   'benchmarks/schema/blind-packet.v1.schema.json',
@@ -27,6 +28,7 @@ const stage1CheckpointFiles = [
 const stage1Scripts = {
   'stage1:evaluate': 'node scripts/evaluate-rewrite-benchmark.mjs',
   'stage1:dry-run': 'npm run build && node scripts/run-stage1-dry-run.mjs',
+  'stage1:human-packet': 'npm run build && node scripts/run-stage1-human-packet.mjs',
 };
 
 function candidateFiles() {

--- a/scripts/run-stage1-human-packet.mjs
+++ b/scripts/run-stage1-human-packet.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, realpathSync, writeFileSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import {
+  BASELINE_COMMIT,
+  STAGE1_COMMIT,
+} from '../dist/stage1-evaluation.js';
+
+function option(name) {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index < 0 || !process.argv[index + 1]) throw new Error(`Missing --${name}.`);
+  return process.argv[index + 1];
+}
+
+function writeJson(root, name, value) {
+  writeFileSync(join(root, name), `${JSON.stringify(value, null, 2)}\n`, { flag: 'wx' });
+}
+
+function checkoutable(commit) {
+  try {
+    execFileSync('git', ['cat-file', '-t', commit], { cwd: repositoryRoot, stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (process.argv.includes('--fabricate-human-ratings')) {
+  throw new Error('Human evidence cannot be fabricated.');
+}
+
+const repositoryRoot = realpathSync(resolve(dirname(new URL(import.meta.url).pathname), '..'));
+const outputOption = option('out');
+if (!isAbsolute(outputOption)) throw new Error('Human packet output must use an absolute path.');
+const outputRoot = resolve(outputOption);
+const outputParent = realpathSync(dirname(outputRoot));
+const resolvedOutputRoot = join(outputParent, basename(outputRoot));
+const repositoryTrees = (() => {
+  const trees = new Set([repositoryRoot]);
+  const porcelain = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+  });
+  for (const line of porcelain.split('\n')) {
+    if (line.startsWith('worktree ')) trees.add(realpathSync(line.slice('worktree '.length)));
+  }
+  return trees;
+})();
+function outsideRepository(path) {
+  for (const root of repositoryTrees) {
+    const relativeOutput = relative(root, path);
+    if (!(relativeOutput === '..' || relativeOutput.startsWith(`..${sep}`))) return false;
+  }
+  return true;
+}
+if (!outsideRepository(resolvedOutputRoot)) {
+  throw new Error('Human packet output must stay outside the repository and every worktree.');
+}
+
+const mergedHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repositoryRoot, encoding: 'utf8' }).trim();
+const baselineCheckoutable = checkoutable(BASELINE_COMMIT);
+const stage1CommitCheckoutable = checkoutable(STAGE1_COMMIT);
+const identities = {
+  baselineCommit: BASELINE_COMMIT,
+  stage1Commit: STAGE1_COMMIT,
+  mergedHead,
+  baselineCheckoutable,
+  stage1CommitCheckoutable,
+  exactHeadBindingSatisfied: stage1CommitCheckoutable,
+  captureAuthorized: false,
+  lockedHumanProtocolDigest: null,
+};
+const blockers = [
+  'human_writer_evidence_deferred',
+  'locked_human_evidence_required',
+  ...(stage1CommitCheckoutable ? [] : ['stage1_commit_uncheckoutable']),
+  'reviewer_roster_verification_deferred',
+  'receipts_unverified',
+];
+const status = {
+  kind: 'hyv-stage1-operator-kit',
+  writerEvidence: false,
+  kitEmitted: true,
+  decision: 'BLOCKED',
+  promotable: false,
+  blockers,
+  lockedHumanProtocolDigest: null,
+  stage1CommitCheckoutable,
+  exactHeadBindingSatisfied: stage1CommitCheckoutable,
+  captureAuthorized: false,
+  receiptsUnverified: true,
+  approvedEncryptedStorage: false,
+};
+const protocolSkeleton = {
+  kind: 'hyv-stage1-preregistration',
+  version: '1',
+  mode: 'locked-human',
+  baseline: { packageVersion: '3.2.0', sourceCommit: BASELINE_COMMIT },
+  stage1: { sourceCommit: STAGE1_COMMIT },
+  benchmark: { manifestDigest: null, partitionDigest: null, partition: 'locked-test', synthetic: false },
+  cases: [],
+  intentToTreat: { expectedAssignments: null, expectedReviewers: null },
+  execution: {
+    provider: null,
+    model: null,
+    modelRevision: null,
+    settingsDigest: null,
+    taskContractDigest: null,
+    rulesetDigest: null,
+    rubricDigest: null,
+  },
+  randomization: { algorithm: 'sha256-counter-v1', commitment: null },
+  reviewerRosterDigest: null,
+  analysis: {
+    statistic: 'paired-preference-rate',
+    decisionRule: 'preference-or-correction-with-workflow-non-regression',
+    margin: null,
+    minimumCases: null,
+    minimumRatings: null,
+    missingRatingPolicy: 'count-as-non-preference',
+    tiePolicy: 'count-as-half',
+    retryPolicy: 'no-retry',
+    routingPolicy: 'precommitted-blind-routing',
+  },
+  rights: {
+    providerDisclosureDigest: null,
+    reviewerDisclosureDigest: null,
+    derivedRetentionDigest: null,
+  },
+  releaseAuditContractDigest: null,
+  registeredAt: null,
+  measures: ['writer_preference', 'correction_versus_confirm', 'workflow_completion', 'workflow_abandonment'],
+  gates: ['semantic', 'copy_spec', 'hygiene', 'preservation', 'cli_mcp_parity', 'backward_compatibility'],
+};
+const operator = `# Stage 1 human-study operator packet
+
+This packet is preparation material only. It is BLOCKED and cannot establish MAR-362 promotion evidence. \`status.json\` is an operator-kit record, not an evaluator report. This kit never sets \`captureAuthorized\` true; checkoutability of \`STAGE1_COMMIT\` is necessary but not sufficient. Kit output under \`--out\` is not approved encrypted custody; \`/tmp\` and other ordinary directories are emit-only.
+
+## Exact-head binding
+
+Do not capture paired Stage 1 arm output until \`STAGE1_COMMIT\` is checkoutable. The merged HEAD squash is not that locked tree. Do not label HEAD bytes as \`stage1.sourceCommit\`. Protocol identity stays \`550ea24f652291dca13757fdbd2f0fa0b5e3f621\`. Baseline capture may use checkoutable \`4e6269121d551c008a34db73077e1e4fea41b3f9\`. While \`stage1CommitCheckoutable\` is false, capture remains unauthorized.
+
+## Rights and provenance
+
+Use only a non-synthetic corpus with documented rights, per-case provenance, provider and reviewer disclosure permission, approved encrypted storage, retention expiry, deletion procedure, and incident owner. Keep writer text and provider outputs outside every repository and worktree. Fill the rights manifest and bind its digests into each case before committing the protocol. Validate the private lane with the approved encrypted root; do not treat kit emission as that root.
+
+## Reviewer roster and trust keys
+
+Pre-register the complete reviewer roster and expected reviewer count. Each reviewer must be a real human writer represented by an externally managed identity and signing key. Populate the external trust store before review; HYV does not create reviewer IDs, keys, signatures, or attestations. The mapping custodian must be distinct from every reviewer, and reviewers must not have unblinding access.
+
+## Provider capture
+
+HYV never calls a provider. For every pre-registered assignment, the operator runs the CLI lifecycle locally: use prepare-rewrite to create the task, explicitly forward that task to the declared provider, capture the response, use apply-rewrite, and complete the lifecycle review or escalation. Preserve immutable provider, model revision, settings, timing, token, cost, outcome, and digest records without storing source prose in exported evidence.
+
+## Blind packet
+
+After validating the complete intent-to-treat run set, the mapping custodian creates the concealed A/B mapping and runs freeze-blind. Failed hard-gate pairs remain in the denominator and are listed as non-reviewable. freezeBlind checks bindings and label leakage; it does not encrypt contents. Store blind contents encrypted at rest in approved storage and keep the mapping concealed until ratings are sealed.
+
+## Human review
+
+Each rostered reviewer rates every reviewable case once. A completed review records blind preference plus correction-versus-confirm for both A and B. An abandoned review records workflow abandonment and no preference or correction fields. Missing ratings count as non-preference. The complete reviewer-by-case matrix is required; an incomplete matrix fails with reviewer_matrix_mismatch.
+
+The protocol uses intent-to-treat and no retry. Every pre-registered assignment stays in the denominator. Timeouts, errors, and hard-gate failures are not retried; hard-gate failures count as failures and remain non-reviewable for pairwise preference.
+
+## External verification
+
+External verification receipts are required for human review, mapping custody, and checkpoint disposition. The runtime validates receipt shape and artifact/protocol/packet binding only; it does not cryptographically verify signatures, roster membership, or trust chains. Treat every imported human record as \`verificationStatus: unverified\` until an external verifier is configured. Use only these purposes: stage1-blind-review, stage1-mapping-custody, and stage1-checkpoint-disposition. Agent scores, \`hyv_score\`, and model ratings are not writer evidence.
+
+## Finish or stop
+
+Seal ratings only after the complete matrix is captured, then reduce against the bound release audit. While human_writer_evidence_deferred is forced, the result remains BLOCKED. Record only STOP or REPEAT_PROTOCOL with an external checkpoint receipt. Never fabricate missing evidence, retry failed assignments, or record PROCEED_TO_MAR_363.
+`;
+const commands = `#!/bin/sh
+npm run stage1:evaluate -- commit-protocol --protocol <uncommitted-protocol.json>
+npm run stage1:evaluate -- preflight --protocol <protocol.json>
+npm run stage1:evaluate -- validate-runs --protocol <protocol.json> --runs <runs.ndjson-or-json>
+npm run stage1:evaluate -- freeze-blind --protocol <protocol.json> --runs <runs> --mapping <mapping.json> --contents <encrypted-contents.json> --non-reviewable <failed-pairs.json>
+npm run stage1:evaluate -- record-rating --packet <packet.json> --ratings <ratings.ndjson> --rating <signed-rating.json>
+npm run stage1:evaluate -- seal-ratings --packet <packet.json> --mapping <mapping.json> --ratings <ratings.ndjson>
+npm run stage1:evaluate -- reduce --protocol <protocol.json> --runs <runs> --packet <packet.json> --mapping <mapping.json> --ratings <ratings.ndjson> --seal <seal.json> --release-audit <audit.json>
+npm run stage1:evaluate -- record-checkpoint-disposition --report <report.json> --disposition <STOP|REPEAT_PROTOCOL> --attestation <external-receipt.json>
+`;
+const templates = `# Empty evidence slots
+
+These JSON files are deliberately incomplete and must not be submitted to the evaluator as written.
+
+- roster.json: add the approved human reviewer roster and expected reviewer count, then compute its canonical digest.
+- rights-manifest.json: add corpus-level custody and per-case rights and provenance records without copying private prose here.
+- trust-keys.json: add externally managed reviewer and custodian public keys. Do not claim verification until an external verifier has produced a bound receipt.
+- mapping.json: the mapping custodian fills this after protocol commitment. The custodian must not be a reviewer.
+- rating.json: a rostered human reviewer fills and externally signs this after blind review. Automation must not fill identity, preference, workflow, or attestation fields.
+`;
+
+mkdirSync(outputRoot, { recursive: false, mode: 0o700 });
+if (!outsideRepository(realpathSync(outputRoot))) {
+  throw new Error('Human packet output must stay outside the repository and every worktree.');
+}
+const examplesRoot = join(outputRoot, 'examples');
+mkdirSync(examplesRoot, { recursive: false, mode: 0o700 });
+writeJson(outputRoot, 'IDENTITIES.json', identities);
+writeFileSync(join(outputRoot, 'OPERATOR.md'), operator, { flag: 'wx' });
+writeFileSync(join(outputRoot, 'COMMANDS.sh'), commands, { flag: 'wx', mode: 0o700 });
+writeJson(outputRoot, 'protocol-skeleton.json', protocolSkeleton);
+writeJson(examplesRoot, 'roster.json', { verificationStatus: 'unverified', reviewers: [] });
+writeJson(examplesRoot, 'rights-manifest.json', { verificationStatus: 'unverified', cases: [] });
+writeJson(examplesRoot, 'trust-keys.json', { verificationStatus: 'unverified', keys: [] });
+writeJson(examplesRoot, 'mapping.json', { verificationStatus: 'unverified' });
+writeJson(examplesRoot, 'rating.json', { verificationStatus: 'unverified' });
+writeFileSync(join(examplesRoot, 'TEMPLATES.md'), templates, { flag: 'wx' });
+writeJson(outputRoot, 'status.json', status);
+process.stdout.write(`${JSON.stringify({ ...status, outputRoot })}\n`);

--- a/src/release-audit.test.ts
+++ b/src/release-audit.test.ts
@@ -9,6 +9,7 @@ const audit = new URL('../scripts/release-audit.mjs', import.meta.url).pathname;
 const stage1Files = [
   'scripts/evaluate-rewrite-benchmark.mjs',
   'scripts/run-stage1-dry-run.mjs',
+  'scripts/run-stage1-human-packet.mjs',
   'benchmarks/schema/protocol-manifest.v1.schema.json',
   'benchmarks/schema/run-event.v1.schema.json',
   'benchmarks/schema/blind-packet.v1.schema.json',
@@ -23,7 +24,7 @@ function fixture(files: Record<string, string>) {
   const directory = mkdtempSync(join(tmpdir(), 'holdyourvoice-audit-'));
   execFileSync('git', ['init', '--quiet'], { cwd: directory });
   const defaults = {
-    'package.json': JSON.stringify({ name: 'audit-fixture', license: 'MIT', files: ['dist', 'Readme.md', 'LICENSE'], scripts: { 'stage1:evaluate': 'node scripts/evaluate-rewrite-benchmark.mjs', 'stage1:dry-run': 'npm run build && node scripts/run-stage1-dry-run.mjs' }, version: '1.0.0', type: 'module', bin: { hyv: 'dist/cli.js' }, engines: { node: '>=20' } }),
+    'package.json': JSON.stringify({ name: 'audit-fixture', license: 'MIT', files: ['dist', 'Readme.md', 'LICENSE'], scripts: { 'stage1:evaluate': 'node scripts/evaluate-rewrite-benchmark.mjs', 'stage1:dry-run': 'npm run build && node scripts/run-stage1-dry-run.mjs', 'stage1:human-packet': 'npm run build && node scripts/run-stage1-human-packet.mjs' }, version: '1.0.0', type: 'module', bin: { hyv: 'dist/cli.js' }, engines: { node: '>=20' } }),
     'mcpb/manifest.json': JSON.stringify({ version: '1.0.0' }),
     'claude-plugin/.claude-plugin/plugin.json': JSON.stringify({ version: '1.0.0' }),
     '.claude-plugin/marketplace.json': JSON.stringify({ plugins: [{ name: 'hold-your-voice', version: '1.0.0' }] }),
@@ -68,6 +69,7 @@ test('requires exact Stage 1 scripts even when the checkpoint files remain', () 
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /Stage 1 script contract has drifted: stage1:evaluate/);
     assert.match(result.stderr, /Stage 1 script contract has drifted: stage1:dry-run/);
+    assert.match(result.stderr, /Stage 1 script contract has drifted: stage1:human-packet/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/src/stage1-human-packet.test.ts
+++ b/src/stage1-human-packet.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+
+function packetFiles(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(root, entry.name);
+    return entry.isDirectory() ? packetFiles(path) : [path];
+  });
+}
+
+test('Stage 1 human packet executes outside the repository and remains blocked without ratings', () => {
+  const parent = mkdtempSync(join(tmpdir(), 'hyv-stage1-human-packet-test-'));
+  const outputRoot = join(parent, 'packet');
+  try {
+    const output = JSON.parse(execFileSync(process.execPath, ['scripts/run-stage1-human-packet.mjs', '--out', outputRoot], { encoding: 'utf8' })) as {
+      kind: string; writerEvidence: boolean; kitEmitted: boolean;
+      decision: string; promotable: boolean; blockers: string[];
+    };
+    assert.equal(output.kind, 'hyv-stage1-operator-kit');
+    assert.equal(output.writerEvidence, false);
+    assert.equal(output.kitEmitted, true);
+    assert.equal(output.decision, 'BLOCKED');
+    assert.equal(output.promotable, false);
+    assert.ok(output.blockers.includes('human_writer_evidence_deferred'));
+    assert.ok(output.blockers.includes('locked_human_evidence_required'));
+    assert.ok(output.blockers.includes('stage1_commit_uncheckoutable'));
+    assert.ok(output.blockers.includes('receipts_unverified'));
+    assert.equal(existsSync(join(outputRoot, 'ratings.ndjson')), false);
+    for (const file of packetFiles(outputRoot)) {
+      assert.doesNotMatch(readFileSync(file, 'utf8'), /"evidenceClass"\s*:\s*"human"/);
+    }
+    const status = JSON.parse(readFileSync(join(outputRoot, 'status.json'), 'utf8')) as {
+      kind: string; writerEvidence: boolean; decision: string; promotable: boolean; blockers: string[];
+    };
+    assert.equal(status.kind, 'hyv-stage1-operator-kit');
+    assert.equal(status.writerEvidence, false);
+    assert.equal(status.decision, output.decision);
+    assert.equal(status.promotable, output.promotable);
+    assert.deepEqual(status.blockers, output.blockers);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test('Stage 1 human packet reports locked commit checkoutability', () => {
+  const parent = mkdtempSync(join(tmpdir(), 'hyv-stage1-human-identities-test-'));
+  const outputRoot = join(parent, 'packet');
+  try {
+    execFileSync(process.execPath, ['scripts/run-stage1-human-packet.mjs', '--out', outputRoot], { stdio: 'pipe' });
+    const identities = JSON.parse(readFileSync(join(outputRoot, 'IDENTITIES.json'), 'utf8')) as {
+      baselineCheckoutable: boolean; stage1CommitCheckoutable: boolean;
+      exactHeadBindingSatisfied: boolean; captureAuthorized: boolean;
+    };
+    assert.equal(identities.baselineCheckoutable, true);
+    assert.equal(identities.stage1CommitCheckoutable, false);
+    assert.equal(identities.exactHeadBindingSatisfied, false);
+    assert.equal(identities.captureAuthorized, false);
+    const operator = readFileSync(join(outputRoot, 'OPERATOR.md'), 'utf8');
+    assert.match(operator, /Do not capture paired Stage 1 arm output until/);
+    assert.match(operator, /verificationStatus: unverified/);
+    const rating = JSON.parse(readFileSync(join(outputRoot, 'examples', 'rating.json'), 'utf8')) as { verificationStatus: string };
+    assert.equal(rating.verificationStatus, 'unverified');
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test('Stage 1 human packet refuses a relative output path', () => {
+  assert.throws(
+    () => execFileSync(process.execPath, ['scripts/run-stage1-human-packet.mjs', '--out', 'stage1-human-output'], { stdio: 'pipe' }),
+    /Human packet output must use an absolute path/,
+  );
+});
+
+test('Stage 1 human packet refuses repository output', () => {
+  assert.throws(
+    () => execFileSync(process.execPath, ['scripts/run-stage1-human-packet.mjs', '--out', join(process.cwd(), 'stage1-human-output')], { stdio: 'pipe' }),
+    /Human packet output must stay outside the repository and every worktree/,
+  );
+});
+
+test('Stage 1 human packet refuses every linked worktree and the primary clone', () => {
+  const porcelain = execFileSync('git', ['worktree', 'list', '--porcelain'], { encoding: 'utf8' });
+  const trees = porcelain.split('\n').flatMap((line) => (line.startsWith('worktree ') ? [realpathSync(line.slice('worktree '.length))] : []));
+  const gitCommonDir = realpathSync(execFileSync('git', ['rev-parse', '--git-common-dir'], { encoding: 'utf8' }).trim());
+  trees.push(dirname(gitCommonDir));
+  for (const root of new Set(trees)) {
+    assert.throws(
+      () => execFileSync(process.execPath, ['scripts/run-stage1-human-packet.mjs', '--out', join(root, 'stage1-human-output')], { stdio: 'pipe' }),
+      /Human packet output must stay outside the repository and every worktree/,
+    );
+  }
+});
+
+test('Stage 1 human packet refuses a symlinked ancestor into the repository', () => {
+  const parent = mkdtempSync(join(tmpdir(), 'hyv-stage1-human-symlink-test-'));
+  const repositoryTarget = join(process.cwd(), 'stage1-human-symlink-target');
+  mkdirSync(repositoryTarget);
+  symlinkSync(repositoryTarget, join(parent, 'redirect'));
+  try {
+    assert.throws(
+      () => execFileSync(process.execPath, ['scripts/run-stage1-human-packet.mjs', '--out', join(parent, 'redirect', 'packet')], { stdio: 'pipe' }),
+      /Human packet output must stay outside the repository and every worktree/,
+    );
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+    rmSync(repositoryTarget, { recursive: true, force: true });
+  }
+});
+
+test('Stage 1 human packet refuses fabricated human ratings', () => {
+  assert.throws(
+    () => execFileSync(process.execPath, ['scripts/run-stage1-human-packet.mjs', '--fabricate-human-ratings'], { stdio: 'pipe' }),
+    /Human evidence cannot be fabricated/,
+  );
+});

--- a/src/stage1-human-packet.test.ts
+++ b/src/stage1-human-packet.test.ts
@@ -4,6 +4,16 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, realpath
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
+import { BASELINE_COMMIT, STAGE1_COMMIT } from './stage1-evaluation.js';
+
+function gitObjectExists(commit: string): boolean {
+  try {
+    execFileSync('git', ['cat-file', '-t', commit], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function packetFiles(root: string): string[] {
   return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
@@ -27,7 +37,7 @@ test('Stage 1 human packet executes outside the repository and remains blocked w
     assert.equal(output.promotable, false);
     assert.ok(output.blockers.includes('human_writer_evidence_deferred'));
     assert.ok(output.blockers.includes('locked_human_evidence_required'));
-    assert.ok(output.blockers.includes('stage1_commit_uncheckoutable'));
+    assert.equal(output.blockers.includes('stage1_commit_uncheckoutable'), !gitObjectExists(STAGE1_COMMIT));
     assert.ok(output.blockers.includes('receipts_unverified'));
     assert.equal(existsSync(join(outputRoot, 'ratings.ndjson')), false);
     for (const file of packetFiles(outputRoot)) {
@@ -55,9 +65,9 @@ test('Stage 1 human packet reports locked commit checkoutability', () => {
       baselineCheckoutable: boolean; stage1CommitCheckoutable: boolean;
       exactHeadBindingSatisfied: boolean; captureAuthorized: boolean;
     };
-    assert.equal(identities.baselineCheckoutable, true);
-    assert.equal(identities.stage1CommitCheckoutable, false);
-    assert.equal(identities.exactHeadBindingSatisfied, false);
+    assert.equal(identities.baselineCheckoutable, gitObjectExists(BASELINE_COMMIT));
+    assert.equal(identities.stage1CommitCheckoutable, gitObjectExists(STAGE1_COMMIT));
+    assert.equal(identities.exactHeadBindingSatisfied, identities.stage1CommitCheckoutable);
     assert.equal(identities.captureAuthorized, false);
     const operator = readFileSync(join(outputRoot, 'OPERATOR.md'), 'utf8');
     assert.match(operator, /Do not capture paired Stage 1 arm output until/);


### PR DESCRIPTION
## Summary
- Adds `npm run stage1:human-packet` so operators can emit a locked-human study kit without minting ratings, calling providers, or claiming MAR-362 pass.
- `--out` must be absolute and outside every git worktree plus the primary clone; `--fabricate-human-ratings` is refused. `status.json` is an operator-kit record (`writerEvidence: false`), not an evaluator report.
- Documents that `STAGE1_COMMIT` `550ea24f652291dca13757fdbd2f0fa0b5e3f621` is not checkoutable after the PR #27 squash, and that agent/`hyv_score`/model ratings are not writer evidence.

## Checkpoint status
- MAR-362 remains **unpassed** / In Progress. This PR is the blocked-path operator packet only.
- MAR-363, MAR-364, and MAR-365 were not started.
- No writer-outcome, promotion, or release claim.

## Test plan
- [x] `npm test` (222 passing, including packet path/worktree/fabrication cases)
- [x] `npm run check:release`
- [x] `git diff --check`
- [ ] CI `verify` on this PR
- [ ] Confirm kit `--out` inside the primary clone or another worktree is refused
- [ ] Confirm emitted `status.json` has `decision: BLOCKED`, `promotable: false`, `writerEvidence: false`


Made with [Cursor](https://cursor.com)