### PR TITLE
feat(rewrite): add judgment envelopes and contiguous range edits

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -212,6 +212,33 @@ test('prepares and applies the same constrained rewrite task without a provider 
   }
 });
 
+test('prepares and reduces pre-edit judgment envelopes through CLI', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'holdyourvoice-cli-judgment-'));
+  try {
+    const first = join(directory, 'first.md'); const second = join(directory, 'second.md'); const profile = join(directory, 'profile.json');
+    const draft = join(directory, 'draft.md');
+    writeFileSync(first, 'I write plainly. I name the work.'); writeFileSync(second, 'I keep the mechanism clear. I avoid filler.');
+    writeFileSync(draft, 'I leverage the answer.');
+    assert.equal(run(['profile', profile, first, second, '--avoid=leverage']).status, 0);
+    const envelopes = (['triage', 'argument', 'form'] as const).map((kind) => {
+      const taskPath = join(directory, `${kind}.json`);
+      assert.equal(run(['prepare-judgment', 'pre-edit', kind, draft, profile, taskPath]).status, 0);
+      const task = JSON.parse(readFileSync(taskPath, 'utf8'));
+      const envelopePath = join(directory, `${kind}-envelope.json`);
+      writeFileSync(envelopePath, JSON.stringify({
+        version: '1', stage: 'pre-edit', judgmentType: kind, taskFingerprint: task.taskFingerprint,
+        bindings: { ...task.bindings, evaluatorId: 'writer.1' }, findings: [], decision: 'SHIP',
+      }));
+      return envelopePath;
+    });
+    const result = run(['reduce-judgment', ...envelopes]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).decision, 'SHIP');
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test('prepares, submits, and inspects a normal lifecycle through CLI canonical envelopes', () => {
   const directory = mkdtempSync(join(tmpdir(), 'holdyourvoice-cli-lifecycle-'));
   try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,13 +10,14 @@ import { cleanHygiene, finalOutputCheck, inspectHygiene } from './hygiene.js';
 import { analyze, rewritePrompt, verify, verifyWithCopySpec } from './pipeline.js';
 import { parseProfile } from './profile.js';
 import { evaluateRewriteResponse, parseRewriteTask, prepareRewriteTask } from './rewrite-task.js';
+import { parseJudgmentEnvelope, preparePostCandidateJudgment, preparePreEditJudgment, reducePostCandidate, reducePreEdit } from './judgment-task.js';
 import type { ApprovalCapabilityEnvelopeV1, DeterministicVerificationArtifactV1, RewriteLifecycleArtifactV1, RewriteLifecycleBindingV1, RewriteReceipt, SemanticPolicy, SemanticReviewTaskV1, SemanticViolation } from './contracts.js';
 import { canonicalJson, parseCanonicalJson } from './canonical-json.js';
 import { finalizeLifecycle, inspectLifecycle, prepareLifecycle, recordApprovedLearning, submitSemanticVerdict, validateFinalApproval } from './lifecycle-adapter.js';
 import { buildProfile } from './voice-dna.js';
 import { loadApprovalContext } from './approval-context.js';
 
-const usage = 'Commands: profile, analyze, hygiene, final-check, batch-analyze, rewrite-prompt, prepare-rewrite, apply-rewrite, verify, verify-spec, lifecycle, learning, patterns, mcp';
+const usage = 'Commands: profile, analyze, hygiene, final-check, batch-analyze, rewrite-prompt, prepare-rewrite, apply-rewrite, prepare-judgment, reduce-judgment, verify, verify-spec, lifecycle, learning, patterns, mcp';
 const MAX_JSON_BYTES = 1024 * 1024;
 
 function input(path: string): string {
@@ -256,6 +257,25 @@ export async function runCli(args: string[]): Promise<number> {
     const result = evaluateRewriteResponse(parseRewriteTask(JSON.parse(input(taskPath))), input(responsePath), readProfile(profilePath));
     json(result);
     return result.status === 'accepted' ? 0 : 2;
+  }
+  if (command === 'prepare-judgment') {
+    const [stage, kind, draft, profilePath, output, candidatePath] = rest;
+    if (!stage || !kind || !draft || !profilePath || !output) throw new Error('Usage: hyv prepare-judgment pre-edit|post-candidate kind draft.md profile.json task.json [candidate.md]');
+    if (stage === 'post-candidate' && !candidatePath) throw new Error('Usage: hyv prepare-judgment post-candidate kind draft.md profile.json task.json candidate.md');
+    const profile = readProfile(profilePath);
+    const task = stage === 'pre-edit'
+      ? preparePreEditJudgment(input(draft), profile, kind as 'triage' | 'argument' | 'form')
+      : preparePostCandidateJudgment(input(draft), input(candidatePath ?? ''), profile, kind as 'argument' | 'polarity' | 'form' | 'flatness' | 'semantic');
+    writeFileSync(output, `${JSON.stringify(task, null, 2)}\n`);
+    json({ version: task.version, stage: task.stage, judgmentType: task.judgmentType, taskFingerprint: task.taskFingerprint });
+    return 0;
+  }
+  if (command === 'reduce-judgment') {
+    if (rest.length < 3) throw new Error('Usage: hyv reduce-judgment envelope.json envelope.json [envelope.json...]');
+    const envelopes = rest.map((path) => parseJudgmentEnvelope(JSON.parse(input(path))));
+    const stage = envelopes[0]?.stage;
+    json(stage === 'pre-edit' ? reducePreEdit(envelopes) : reducePostCandidate(envelopes));
+    return 0;
   }
   if (command === 'verify') {
     const [original, candidate, profilePath, briefPath] = rest;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -241,7 +241,88 @@ export interface RewriteResponse {
   replacements: RewriteReplacement[];
 }
 
-export type RewriteFailureCode = 'invalid_json' | 'invalid_response_shape' | 'invalid_response_version' | 'task_fingerprint_mismatch' | 'duplicate_sentence_id' | 'unknown_sentence_id' | 'ineligible_sentence_id' | 'invalid_replacement_text' | 'response_too_large';
+export interface SentenceRange {
+  startSentenceId: number;
+  endSentenceId: number;
+}
+
+export interface RewriteRangeOperation {
+  startSentenceId: number;
+  endSentenceId: number;
+  text: string;
+}
+
+export interface HygieneSourceFinding {
+  kind: 'hygiene';
+  start: number;
+  end: number;
+  codepoint: string;
+  eligible: boolean;
+}
+
+export interface HygieneRangeOperation {
+  start: number;
+  end: number;
+  text: string;
+}
+
+export interface RewriteResponseV2 {
+  version: '2';
+  taskFingerprint: string;
+  operations: RewriteRangeOperation[];
+  hygieneOperations?: HygieneRangeOperation[];
+}
+
+export type RewriteFailureCode = 'invalid_json' | 'invalid_response_shape' | 'invalid_response_version' | 'task_fingerprint_mismatch' | 'duplicate_sentence_id' | 'unknown_sentence_id' | 'ineligible_sentence_id' | 'invalid_replacement_text' | 'response_too_large' | 'overlapping_range' | 'noncontiguous_range' | 'out_of_order_range' | 'partly_locked_range' | 'ineligible_hygiene_offset';
+
+export type JudgmentStage = 'pre-edit' | 'post-candidate';
+export type JudgmentKind = 'triage' | 'argument' | 'form' | 'polarity' | 'flatness' | 'semantic';
+export type PreEditDecision = 'SHIP' | 'EDIT' | 'REBUILD';
+export type PostCandidateDecision = 'CLEAR' | 'ESCALATE' | 'REBUILD';
+
+export interface JudgmentFindingV1 {
+  kind: JudgmentKind;
+  unbounded?: boolean;
+  ranges?: SentenceRange[];
+}
+
+export interface JudgmentBindingsV1 {
+  sourceHash: string;
+  candidateHash?: string;
+  profileId: string;
+  profileRevisionDigest: string;
+  rulesetVersion: string;
+  evaluatorId: string;
+  evidenceScope: { sentenceIds: number[] };
+}
+
+export interface JudgmentTaskV1 {
+  version: '1';
+  stage: JudgmentStage;
+  judgmentType: JudgmentKind;
+  taskFingerprint: string;
+  draft?: string;
+  candidate?: string;
+  bindings: Omit<JudgmentBindingsV1, 'evaluatorId'>;
+  allowedDecisions: Array<PreEditDecision | PostCandidateDecision>;
+}
+
+export interface JudgmentEnvelopeV1 {
+  version: '1';
+  stage: JudgmentStage;
+  judgmentType: JudgmentKind;
+  taskFingerprint: string;
+  bindings: JudgmentBindingsV1;
+  findings: JudgmentFindingV1[];
+  decision: PreEditDecision | PostCandidateDecision;
+  editScope?: { ranges: SentenceRange[] };
+}
+
+export interface PreEditReduction {
+  decision: PreEditDecision;
+  editScope: { ranges: SentenceRange[] };
+  reason?: 'unbounded_argument_failure';
+}
 
 export interface RewriteFailure {
   code: RewriteFailureCode;
@@ -255,6 +336,8 @@ export interface RewriteReceipt {
   responseFingerprint: string;
   adapterIds: string[];
   replacementSentenceIds?: number[];
+  operationRanges?: SentenceRange[];
+  mode?: 'SHIP' | 'EDIT';
 }
 
 export interface RewriteApplyResult {

--- a/src/hygiene.test.ts
+++ b/src/hygiene.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { cleanHygiene, finalOutputCheck, inspectHygiene } from './hygiene.js';
+import { cleanHygiene, finalOutputCheck, hygieneSourceFindings, inspectHygiene } from './hygiene.js';
 
 test('reports zero-width, bidi, tag, and unusual-space characters with exact offsets', () => {
   const text = `one\u200Btwo\u202Ethree\u{E0001}\u00A0four`;
@@ -36,6 +36,13 @@ test('leaves clean text byte-for-byte unchanged', () => {
   assert.equal(result.changed, false);
   assert.deepEqual(result.changes, []);
   assert.deepEqual(result.report.hits, []);
+});
+
+test('projects eligible hygiene hits as source-offset findings', () => {
+  const findings = hygieneSourceFindings('\uFEFFplain');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.start, 0);
+  assert.equal(findings[0]?.eligible, true);
 });
 
 test('groups repeated report-only hits and preserves supplementary characters', () => {

--- a/src/hygiene.ts
+++ b/src/hygiene.ts
@@ -1,4 +1,4 @@
-import type { FinalOutputCheck, HygieneChange, HygieneHit, HygieneKind, HygieneReport } from './contracts.js';
+import type { FinalOutputCheck, HygieneChange, HygieneHit, HygieneKind, HygieneReport, HygieneSourceFinding } from './contracts.js';
 
 type CharacterPolicy = { kind: HygieneKind; label: string; fix: 'remove' | 'none' };
 
@@ -81,6 +81,13 @@ function scanHygiene(text: string, clean: boolean): { report: HygieneReport; cle
 
 export function inspectHygiene(text: string): HygieneReport {
   return scanHygiene(text, false).report;
+}
+
+export function hygieneSourceFindings(text: string): HygieneSourceFinding[] {
+  return inspectHygiene(text).hits.flatMap((hit) => hit.offsets.map((start) => {
+    const character = String.fromCodePoint(text.codePointAt(start) as number);
+    return { kind: 'hygiene' as const, start, end: start + character.length, codepoint: hit.codepoint, eligible: hit.fix === 'remove' };
+  }));
 }
 
 export function cleanHygiene(text: string): { report: HygieneReport; cleaned: string; changed: boolean; changes: HygieneChange[] } {

--- a/src/judgment-task.test.ts
+++ b/src/judgment-task.test.ts
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { bindJudgmentEnvelope, preparePostCandidateJudgment, preparePreEditJudgment, reducePostCandidate, reducePreEdit } from './judgment-task.js';
+import { applyRewriteResponse, applyShip, prepareRewriteTask } from './rewrite-task.js';
+import { hygieneSourceFindings } from './hygiene.js';
+import { buildProfile } from './voice-dna.js';
+
+const profile = buildProfile([
+  'I write clear notes. I keep the mechanism visible.',
+  'I name the trade-off. Then I make the next step plain.',
+], ['leverage']);
+
+function envelope(task: ReturnType<typeof preparePreEditJudgment>, decision: 'SHIP' | 'EDIT' | 'REBUILD', extra: Record<string, unknown> = {}) {
+  return {
+    version: '1' as const,
+    stage: task.stage,
+    judgmentType: task.judgmentType,
+    taskFingerprint: task.taskFingerprint,
+    bindings: { ...task.bindings, evaluatorId: 'writer.1' },
+    findings: [],
+    decision,
+    ...extra,
+  };
+}
+
+test('pre-edit findings select SHIP, bounded EDIT, or REBUILD', () => {
+  const draft = 'I leverage the answer. The launch is on 14 August.';
+  const triage = preparePreEditJudgment(draft, profile, 'triage');
+  const argument = preparePreEditJudgment(draft, profile, 'argument');
+  const form = preparePreEditJudgment(draft, profile, 'form');
+  const ship = reducePreEdit([
+    bindJudgmentEnvelope(triage, envelope(triage, 'SHIP')),
+    bindJudgmentEnvelope(argument, envelope(argument, 'SHIP')),
+    bindJudgmentEnvelope(form, envelope(form, 'SHIP')),
+  ]);
+  assert.equal(ship.decision, 'SHIP');
+  const edit = reducePreEdit([
+    bindJudgmentEnvelope(triage, envelope(triage, 'EDIT', { editScope: { ranges: [{ startSentenceId: 1, endSentenceId: 1 }] } })),
+    bindJudgmentEnvelope(argument, envelope(argument, 'SHIP')),
+    bindJudgmentEnvelope(form, envelope(form, 'SHIP')),
+  ]);
+  assert.equal(edit.decision, 'EDIT');
+  assert.deepEqual(edit.editScope.ranges, [{ startSentenceId: 1, endSentenceId: 1 }]);
+  const rebuild = reducePreEdit([
+    bindJudgmentEnvelope(triage, envelope(triage, 'SHIP')),
+    bindJudgmentEnvelope(argument, envelope(argument, 'REBUILD')),
+    bindJudgmentEnvelope(form, envelope(form, 'SHIP')),
+  ]);
+  assert.equal(rebuild.decision, 'REBUILD');
+});
+
+test('unbounded argument failure can recommend only rebuild', () => {
+  const draft = 'I leverage the answer. The launch is on 14 August.';
+  const triage = preparePreEditJudgment(draft, profile, 'triage');
+  const argument = preparePreEditJudgment(draft, profile, 'argument');
+  const form = preparePreEditJudgment(draft, profile, 'form');
+  const reduced = reducePreEdit([
+    bindJudgmentEnvelope(triage, envelope(triage, 'EDIT', { editScope: { ranges: [{ startSentenceId: 1, endSentenceId: 1 }] } })),
+    bindJudgmentEnvelope(argument, envelope(argument, 'EDIT', { findings: [{ kind: 'argument', unbounded: true }] })),
+    bindJudgmentEnvelope(form, envelope(form, 'SHIP')),
+  ]);
+  assert.equal(reduced.decision, 'REBUILD');
+  assert.equal(reduced.reason, 'unbounded_argument_failure');
+});
+
+test('paragraph-level findings cannot unlock text without named ranges', () => {
+  const draft = 'I leverage the answer. The launch is on 14 August.';
+  const triage = preparePreEditJudgment(draft, profile, 'triage');
+  const argument = preparePreEditJudgment(draft, profile, 'argument');
+  const form = preparePreEditJudgment(draft, profile, 'form');
+  assert.throws(() => reducePreEdit([
+    bindJudgmentEnvelope(triage, envelope(triage, 'EDIT')),
+    bindJudgmentEnvelope(argument, envelope(argument, 'SHIP')),
+    bindJudgmentEnvelope(form, envelope(form, 'SHIP')),
+  ]), /contiguous sentence ranges/);
+});
+
+test('deleting one eligible sentence or merging two adjacent sentences succeeds', () => {
+  const draft = 'I leverage the answer. I leverage the second point. The launch is on 14 August.';
+  const task = prepareRewriteTask(draft, profile, undefined, undefined, [1, 2]);
+  const deleted = applyRewriteResponse(task, {
+    version: '2',
+    taskFingerprint: task.fingerprint,
+    operations: [{ startSentenceId: 1, endSentenceId: 1, text: '' }],
+  });
+  assert.equal(deleted.status, 'accepted');
+  assert.equal(deleted.candidate, ' I leverage the second point. The launch is on 14 August.');
+  const merged = applyRewriteResponse(task, {
+    version: '2',
+    taskFingerprint: task.fingerprint,
+    operations: [{ startSentenceId: 1, endSentenceId: 2, text: 'I use both points.' }],
+  });
+  assert.equal(merged.status, 'accepted');
+  assert.equal(merged.candidate, 'I use both points. The launch is on 14 August.');
+});
+
+test('overlapping, noncontiguous, out-of-order, or partly locked ranges fail before candidate construction', () => {
+  const draft = 'I leverage the answer. The launch is on 14 August. I keep the mechanism visible.';
+  const task = prepareRewriteTask(draft, profile);
+  const overlap = applyRewriteResponse(task, {
+    version: '2',
+    taskFingerprint: task.fingerprint,
+    operations: [
+      { startSentenceId: 1, endSentenceId: 1, text: 'I use the answer.' },
+      { startSentenceId: 1, endSentenceId: 1, text: 'I choose the answer.' },
+    ],
+  });
+  assert.equal(overlap.status, 'repairable');
+  assert.equal(overlap.candidate, undefined);
+  assert.equal(overlap.failures[0]?.code, 'overlapping_range');
+  const locked = applyRewriteResponse(task, {
+    version: '2',
+    taskFingerprint: task.fingerprint,
+    operations: [{ startSentenceId: 1, endSentenceId: 2, text: 'I use the answer. The launch is on 14 August.' }],
+  });
+  assert.equal(locked.status, 'repairable');
+  assert.equal(locked.failures[0]?.code, 'partly_locked_range');
+});
+
+test('SHIP returns original bytes without a model response body', () => {
+  const draft = 'I leverage the answer. The launch is on 14 August.';
+  const task = prepareRewriteTask(draft, profile);
+  const shipped = applyShip(task);
+  assert.equal(shipped.status, 'accepted');
+  assert.equal(shipped.candidate, draft);
+  assert.equal(shipped.receipt.mode, 'SHIP');
+  const viaResponse = applyRewriteResponse(task, { version: '1', mode: 'SHIP', taskFingerprint: task.fingerprint });
+  assert.equal(viaResponse.candidate, draft);
+});
+
+test('hygiene changes occur only through eligible source-offset findings', () => {
+  const draft = `\uFEFFI leverage the answer.`;
+  const findings = hygieneSourceFindings(draft);
+  assert.equal(findings[0]?.eligible, true);
+  const task = prepareRewriteTask(draft, profile);
+  const rejected = applyRewriteResponse(task, {
+    version: '2',
+    taskFingerprint: task.fingerprint,
+    operations: [],
+    hygieneOperations: [{ start: 1, end: 2, text: '' }],
+  });
+  assert.equal(rejected.status, 'repairable');
+  assert.equal(rejected.failures[0]?.code, 'ineligible_hygiene_offset');
+  const cleaned = applyRewriteResponse(task, {
+    version: '2',
+    taskFingerprint: task.fingerprint,
+    operations: [{ startSentenceId: 1, endSentenceId: 1, text: 'I use the answer.' }],
+    hygieneOperations: [{ start: findings[0]!.start, end: findings[0]!.end, text: '' }],
+  });
+  assert.equal(cleaned.status, 'accepted');
+  assert.equal(cleaned.candidate, 'I use the answer.');
+});
+
+test('post-candidate reduction requires the full judgment set', () => {
+  const draft = 'I write clear notes.';
+  const candidate = 'I write clear notes.';
+  const kinds = ['argument', 'polarity', 'form', 'flatness', 'semantic'] as const;
+  const envelopes = kinds.map((kind) => {
+    const task = preparePostCandidateJudgment(draft, candidate, profile, kind);
+    return bindJudgmentEnvelope(task, {
+      version: '1',
+      stage: 'post-candidate',
+      judgmentType: kind,
+      taskFingerprint: task.taskFingerprint,
+      bindings: { ...task.bindings, evaluatorId: 'writer.1' },
+      findings: [],
+      decision: 'CLEAR',
+    });
+  });
+  assert.equal(reducePostCandidate(envelopes).decision, 'CLEAR');
+});

--- a/src/judgment-task.ts
+++ b/src/judgment-task.ts
@@ -1,0 +1,165 @@
+import { createHash } from 'node:crypto';
+import type {
+  JudgmentEnvelopeV1,
+  JudgmentFindingV1,
+  JudgmentKind,
+  JudgmentStage,
+  JudgmentTaskV1,
+  PostCandidateDecision,
+  PreEditDecision,
+  PreEditReduction,
+  Profile,
+  SentenceRange,
+} from './contracts.js';
+import { canonicalJson } from './canonical-json.js';
+import { sentences } from './text.js';
+import { HYV_VERSION } from './version.js';
+
+const PRE_EDIT_KINDS: JudgmentKind[] = ['triage', 'argument', 'form'];
+const POST_CANDIDATE_KINDS: JudgmentKind[] = ['argument', 'polarity', 'form', 'flatness', 'semantic'];
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function digestCanonical(value: unknown): string {
+  return digest(canonicalJson(value));
+}
+
+function profileIdentity(profile: Profile): { profileId: string; profileRevisionDigest: string } {
+  if (profile.version === '3') return { profileId: profile.id, profileRevisionDigest: profile.revisionDigest };
+  const legacy = `legacy-v2:${digestCanonical(profile)}`;
+  return { profileId: legacy, profileRevisionDigest: legacy };
+}
+
+function fingerprintTask(task: Omit<JudgmentTaskV1, 'taskFingerprint'>): string {
+  return digest(`hyv:judgment-task:v1\0${canonicalJson(task)}`);
+}
+
+function sentenceIds(text: string): number[] {
+  return sentences(text).map((sentence) => sentence.index);
+}
+
+function isRange(value: unknown): value is SentenceRange {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+    && Number.isInteger((value as SentenceRange).startSentenceId)
+    && Number.isInteger((value as SentenceRange).endSentenceId)
+    && (value as SentenceRange).startSentenceId >= 1
+    && (value as SentenceRange).endSentenceId >= (value as SentenceRange).startSentenceId;
+}
+
+function rangesContiguous(ranges: SentenceRange[]): boolean {
+  return ranges.every((range) => range.endSentenceId >= range.startSentenceId);
+}
+
+export function parseJudgmentEnvelope(value: unknown): JudgmentEnvelopeV1 {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Judgment envelope must be an object.');
+  const envelope = value as Partial<JudgmentEnvelopeV1>;
+  if (envelope.version !== '1') throw new Error('Judgment envelope version must be "1".');
+  if (envelope.stage !== 'pre-edit' && envelope.stage !== 'post-candidate') throw new Error('Judgment stage is invalid.');
+  if (typeof envelope.judgmentType !== 'string' || typeof envelope.taskFingerprint !== 'string' || envelope.taskFingerprint.length !== 64) {
+    throw new Error('Judgment envelope is missing a bound task.');
+  }
+  if (!envelope.bindings || typeof envelope.bindings !== 'object' || typeof envelope.bindings.sourceHash !== 'string' || typeof envelope.bindings.evaluatorId !== 'string') {
+    throw new Error('Judgment envelope is missing bindings.');
+  }
+  if (!Array.isArray(envelope.findings) || typeof envelope.decision !== 'string') throw new Error('Judgment envelope is missing findings or a decision.');
+  for (const [index, finding] of envelope.findings.entries()) {
+    if (!finding || typeof finding !== 'object' || typeof finding.kind !== 'string') throw new Error(`Finding ${index} is invalid.`);
+    if (finding.ranges && (!Array.isArray(finding.ranges) || !finding.ranges.every(isRange))) throw new Error(`Finding ${index} ranges are invalid.`);
+  }
+  if (envelope.editScope && (!Array.isArray(envelope.editScope.ranges) || !envelope.editScope.ranges.every(isRange))) {
+    throw new Error('Edit scope ranges are invalid.');
+  }
+  return envelope as JudgmentEnvelopeV1;
+}
+
+function prepareTask(stage: JudgmentStage, judgmentType: JudgmentKind, draft: string, profile: Profile, candidate?: string): JudgmentTaskV1 {
+  const identity = profileIdentity(profile);
+  const allowedDecisions = stage === 'pre-edit' ? ['SHIP', 'EDIT', 'REBUILD'] as PreEditDecision[] : ['CLEAR', 'ESCALATE', 'REBUILD'] as PostCandidateDecision[];
+  const base: Omit<JudgmentTaskV1, 'taskFingerprint'> = {
+    version: '1',
+    stage,
+    judgmentType,
+    ...(stage === 'pre-edit' ? { draft } : { draft, candidate }),
+    bindings: {
+      sourceHash: digest(draft),
+      ...(candidate !== undefined ? { candidateHash: digest(candidate) } : {}),
+      ...identity,
+      rulesetVersion: HYV_VERSION,
+      evidenceScope: { sentenceIds: sentenceIds(candidate ?? draft) },
+    },
+    allowedDecisions,
+  };
+  return { ...base, taskFingerprint: fingerprintTask(base) };
+}
+
+export function preparePreEditJudgment(draft: string, profile: Profile, kind: 'triage' | 'argument' | 'form'): JudgmentTaskV1 {
+  return prepareTask('pre-edit', kind, draft, profile);
+}
+
+export function preparePostCandidateJudgment(draft: string, candidate: string, profile: Profile, kind: 'argument' | 'polarity' | 'form' | 'flatness' | 'semantic'): JudgmentTaskV1 {
+  return prepareTask('post-candidate', kind, draft, profile, candidate);
+}
+
+export function bindJudgmentEnvelope(task: JudgmentTaskV1, envelope: unknown): JudgmentEnvelopeV1 {
+  const parsed = parseJudgmentEnvelope(envelope);
+  if (parsed.taskFingerprint !== task.taskFingerprint) throw new Error('Judgment envelope task fingerprint does not match.');
+  if (parsed.stage !== task.stage || parsed.judgmentType !== task.judgmentType) throw new Error('Judgment envelope type does not match the task.');
+  if (parsed.bindings.sourceHash !== task.bindings.sourceHash) throw new Error('Judgment envelope source hash does not match.');
+  if (task.bindings.candidateHash && parsed.bindings.candidateHash !== task.bindings.candidateHash) throw new Error('Judgment envelope candidate hash does not match.');
+  if (parsed.bindings.profileId !== task.bindings.profileId || parsed.bindings.profileRevisionDigest !== task.bindings.profileRevisionDigest) {
+    throw new Error('Judgment envelope profile binding does not match.');
+  }
+  if (parsed.bindings.rulesetVersion !== task.bindings.rulesetVersion) throw new Error('Judgment envelope ruleset does not match.');
+  if (canonicalJson(parsed.bindings.evidenceScope) !== canonicalJson(task.bindings.evidenceScope)) throw new Error('Judgment envelope evidence scope does not match.');
+  if (!task.allowedDecisions.includes(parsed.decision)) throw new Error('Judgment decision is not allowed at this stage.');
+  return parsed;
+}
+
+function namedRanges(findings: JudgmentFindingV1[]): SentenceRange[] {
+  return findings.flatMap((finding) => finding.ranges ?? []);
+}
+
+export function reducePreEdit(envelopes: JudgmentEnvelopeV1[]): PreEditReduction {
+  if (envelopes.length !== PRE_EDIT_KINDS.length) throw new Error('Pre-edit reduction requires triage, argument, and form envelopes.');
+  const kinds = new Set(envelopes.map((envelope) => envelope.judgmentType));
+  if (PRE_EDIT_KINDS.some((kind) => !kinds.has(kind))) throw new Error('Pre-edit reduction requires triage, argument, and form envelopes.');
+  if (envelopes.some((envelope) => envelope.stage !== 'pre-edit')) throw new Error('Pre-edit reduction rejects post-candidate envelopes.');
+  const argument = envelopes.find((envelope) => envelope.judgmentType === 'argument')!;
+  if (argument.findings.some((finding) => finding.unbounded) || argument.decision === 'REBUILD') {
+    return { decision: 'REBUILD', editScope: { ranges: [] }, reason: argument.findings.some((finding) => finding.unbounded) ? 'unbounded_argument_failure' : undefined };
+  }
+  if (envelopes.some((envelope) => envelope.decision === 'REBUILD')) {
+    return { decision: 'REBUILD', editScope: { ranges: [] } };
+  }
+  const ranges = envelopes.flatMap((envelope) => envelope.editScope?.ranges ?? namedRanges(envelope.findings));
+  if (!rangesContiguous(ranges) || ranges.some((range) => range.endSentenceId < range.startSentenceId)) {
+    throw new Error('Edit scope must name contiguous sentence ranges.');
+  }
+  if (envelopes.every((envelope) => envelope.decision === 'SHIP') && ranges.length === 0) {
+    return { decision: 'SHIP', editScope: { ranges: [] } };
+  }
+  if (ranges.length === 0) throw new Error('Paragraph-level findings cannot unlock text unless they name contiguous sentence ranges.');
+  return { decision: 'EDIT', editScope: { ranges } };
+}
+
+export function reducePostCandidate(envelopes: JudgmentEnvelopeV1[]): { decision: PostCandidateDecision } {
+  if (envelopes.length !== POST_CANDIDATE_KINDS.length) throw new Error('Post-candidate reduction requires argument, polarity, form, flatness, and semantic envelopes.');
+  const kinds = new Set(envelopes.map((envelope) => envelope.judgmentType));
+  if (POST_CANDIDATE_KINDS.some((kind) => !kinds.has(kind))) throw new Error('Post-candidate reduction requires argument, polarity, form, flatness, and semantic envelopes.');
+  if (envelopes.some((envelope) => envelope.stage !== 'post-candidate')) throw new Error('Post-candidate reduction rejects pre-edit envelopes.');
+  if (envelopes.some((envelope) => envelope.decision === 'REBUILD')) return { decision: 'REBUILD' };
+  if (envelopes.some((envelope) => envelope.decision === 'ESCALATE')) return { decision: 'ESCALATE' };
+  if (!envelopes.every((envelope) => envelope.decision === 'CLEAR')) throw new Error('Post-candidate envelopes must CLEAR, ESCALATE, or REBUILD.');
+  return { decision: 'CLEAR' };
+}
+
+export function authorizedSentenceIds(reduction: PreEditReduction): number[] {
+  if (reduction.decision !== 'EDIT') return [];
+  const ids = new Set<number>();
+  for (const range of reduction.editScope.ranges) {
+    for (let id = range.startSentenceId; id <= range.endSentenceId; id += 1) ids.add(id);
+  }
+  return [...ids].sort((left, right) => left - right);
+}

--- a/src/mcp-tools.test.ts
+++ b/src/mcp-tools.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import { analyzeBatchForMcp, analyzeForMcp, applyRewriteForMcp, buildProfileForMcp, clearLearningForMcp, finalOutputCheckForMcp, finalizeLifecycleForMcp, inspectHygieneForMcp, inspectLearningForMcp, inspectLifecycleForMcp, patternsForMcp, prepareLifecycleForMcp, prepareRewriteForMcp, ratifyLearningForMcp, recordApprovedLearningForMcp, recordLearningForMcp, rewritePromptForMcp, submitSemanticVerdictForMcp, supersedeLearningForMcp, validateFinalApprovalForMcp, verifyCopySpecForMcp, verifyForMcp } from './mcp-tools.js';
+import { analyzeBatchForMcp, analyzeForMcp, applyRewriteForMcp, buildProfileForMcp, clearLearningForMcp, finalOutputCheckForMcp, finalizeLifecycleForMcp, inspectHygieneForMcp, inspectLearningForMcp, inspectLifecycleForMcp, patternsForMcp, prepareJudgmentForMcp, prepareLifecycleForMcp, prepareRewriteForMcp, ratifyLearningForMcp, recordApprovedLearningForMcp, recordLearningForMcp, reduceJudgmentForMcp, rewritePromptForMcp, submitSemanticVerdictForMcp, supersedeLearningForMcp, validateFinalApprovalForMcp, verifyCopySpecForMcp, verifyForMcp } from './mcp-tools.js';
 import { canonicalJson } from './canonical-json.js';
 
 const profile = buildProfileForMcp(['I write clearly. I keep the useful detail.', 'I make the call. Then I explain the trade-off.'], ['leverage']);
@@ -186,4 +186,16 @@ test('prepares and applies the rewrite task through MCP helpers', () => {
   }), profileJson);
   assert.equal(result.status, 'needs_semantic_review');
   assert.equal(result.candidate, 'I use the answer with useful detail and clear mechanism.');
+});
+
+test('prepares and reduces judgment envelopes through MCP helpers', () => {
+  const draft = 'I leverage the answer.';
+  const envelopes = (['triage', 'argument', 'form'] as const).map((kind) => {
+    const task = prepareJudgmentForMcp('pre-edit', kind, draft, profileJson);
+    return {
+      version: '1', stage: 'pre-edit', judgmentType: kind, taskFingerprint: task.taskFingerprint,
+      bindings: { ...task.bindings, evaluatorId: 'writer.1' }, findings: [], decision: 'SHIP',
+    };
+  });
+  assert.equal(reduceJudgmentForMcp(JSON.stringify(envelopes)).decision, 'SHIP');
 });

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -6,6 +6,7 @@ import { clearLearning, composeLearning, inspectLearning, type LearningOptions, 
 import { analyze, rewritePrompt, verify, verifyWithCopySpec } from './pipeline.js';
 import { parseProfile } from './profile.js';
 import { evaluateRewriteResponse, parseRewriteTask, prepareRewriteTask } from './rewrite-task.js';
+import { parseJudgmentEnvelope, preparePostCandidateJudgment, preparePreEditJudgment, reducePostCandidate, reducePreEdit } from './judgment-task.js';
 import { buildProfile } from './voice-dna.js';
 import { finalOutputCheck, inspectHygiene } from './hygiene.js';
 import { finalizeLifecycle, inspectLifecycle, prepareLifecycle, recordApprovedLearning, submitSemanticVerdict, validateFinalApproval } from './lifecycle-adapter.js';
@@ -68,6 +69,18 @@ export function prepareRewriteForMcp(draft: string, profileJson: string, copySpe
 
 export function applyRewriteForMcp(taskJson: string, responseJson: string, profileJson: string) {
   return evaluateRewriteResponse(parseRewriteTask(JSON.parse(taskJson)), responseJson, profileFromJson(profileJson));
+}
+
+export function prepareJudgmentForMcp(stage: 'pre-edit' | 'post-candidate', kind: string, draft: string, profileJson: string, candidate?: string) {
+  const profile = profileFromJson(profileJson);
+  return stage === 'pre-edit'
+    ? preparePreEditJudgment(draft, profile, kind as 'triage' | 'argument' | 'form')
+    : preparePostCandidateJudgment(draft, candidate ?? '', profile, kind as 'argument' | 'polarity' | 'form' | 'flatness' | 'semantic');
+}
+
+export function reduceJudgmentForMcp(envelopesJson: string) {
+  const envelopes = parsed<unknown[]>(envelopesJson, 'Judgment envelopes').map(parseJudgmentEnvelope);
+  return envelopes[0]?.stage === 'pre-edit' ? reducePreEdit(envelopes) : reducePostCandidate(envelopes);
 }
 
 export function verifyForMcp(original: string, candidate: string, profileJson: string, writingBriefJson?: string) {

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -64,7 +64,7 @@ test('serves local Claude tools over stdio', async () => {
   assert.equal(code, 0);
   const responses = stdout.trim().split('\n').map((line) => JSON.parse(line) as { id: number; result?: { tools?: Array<{ name: string; inputSchema?: { properties?: Record<string, unknown> }; annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean } }> } });
     const tools = responses.find((response) => response.id === 2)?.result?.tools;
-  assert.deepEqual(tools?.map((tool) => tool.name), ['hyv_build_profile', 'hyv_analyze', 'hyv_hygiene', 'hyv_final_check', 'hyv_rewrite_prompt', 'hyv_prepare_rewrite', 'hyv_apply_rewrite', 'hyv_verify', 'hyv_verify_copy_spec', 'hyv_batch_analyze', 'hyv_patterns', 'hyv_learning_inspect', 'hyv_learning_record', 'hyv_learning_ratify', 'hyv_learning_supersede', 'hyv_learning_migrate', 'hyv_learning_clear', 'hyv_lifecycle_prepare_semantic', 'hyv_lifecycle_submit_verdict', 'hyv_lifecycle_inspect', 'hyv_lifecycle_finalize']);
+  assert.deepEqual(tools?.map((tool) => tool.name), ['hyv_build_profile', 'hyv_analyze', 'hyv_hygiene', 'hyv_final_check', 'hyv_rewrite_prompt', 'hyv_prepare_rewrite', 'hyv_apply_rewrite', 'hyv_prepare_judgment', 'hyv_reduce_judgment', 'hyv_verify', 'hyv_verify_copy_spec', 'hyv_batch_analyze', 'hyv_patterns', 'hyv_learning_inspect', 'hyv_learning_record', 'hyv_learning_ratify', 'hyv_learning_supersede', 'hyv_learning_migrate', 'hyv_learning_clear', 'hyv_lifecycle_prepare_semantic', 'hyv_lifecycle_submit_verdict', 'hyv_lifecycle_inspect', 'hyv_lifecycle_finalize']);
   assert.ok(tools?.filter((tool) => !['hyv_verify', 'hyv_verify_copy_spec', 'hyv_learning_record', 'hyv_learning_ratify', 'hyv_learning_supersede', 'hyv_learning_migrate', 'hyv_learning_clear'].includes(tool.name)).every((tool) => tool.annotations?.readOnlyHint));
   assert.equal(tools?.find((tool) => tool.name === 'hyv_verify')?.annotations?.readOnlyHint, true);
   assert.equal(tools?.find((tool) => tool.name === 'hyv_verify_copy_spec')?.annotations?.readOnlyHint, true);
@@ -89,7 +89,7 @@ test('registers capability tools only with host redaction attestation', async ()
   const [code] = await once(server, 'close'); assert.equal(code, 0); assert.equal(stderr, '');
   const response = stdout.trim().split('\n').map((line) => JSON.parse(line)).find((item) => item.id === 2);
   const names = response.result.tools.map((tool: { name: string }) => tool.name);
-  assert.equal(names.length, 23);
+  assert.equal(names.length, 25);
   assert.ok(names.includes('hyv_lifecycle_validate_final_approval'));
   assert.ok(names.includes('hyv_learning_record_approved'));
   const finalize = response.result.tools.find((tool: { name: string }) => tool.name === 'hyv_lifecycle_finalize');

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { analyzeBatchForMcp, analyzeForMcp, applyRewriteForMcp, buildProfileForMcp, clearLearningForMcp, finalOutputCheckForMcp, finalizeLifecycleForMcp, finalizeRejectionForMcp, inspectHygieneForMcp, inspectLearningForMcp, inspectLifecycleForMcp, migrateLearningForMcp, patternsForMcp, prepareLifecycleForMcp, prepareRewriteForMcp, ratifyLearningForMcp, recordApprovedLearningForMcp, recordLearningForMcp, rewritePromptForMcp, submitSemanticVerdictForMcp, supersedeLearningForMcp, validateFinalApprovalForMcp, verifyCopySpecForMcp, verifyForMcp } from './mcp-tools.js';
+import { analyzeBatchForMcp, analyzeForMcp, applyRewriteForMcp, buildProfileForMcp, clearLearningForMcp, finalOutputCheckForMcp, finalizeLifecycleForMcp, finalizeRejectionForMcp, inspectHygieneForMcp, inspectLearningForMcp, inspectLifecycleForMcp, migrateLearningForMcp, patternsForMcp, prepareJudgmentForMcp, prepareLifecycleForMcp, prepareRewriteForMcp, ratifyLearningForMcp, recordApprovedLearningForMcp, recordLearningForMcp, reduceJudgmentForMcp, rewritePromptForMcp, submitSemanticVerdictForMcp, supersedeLearningForMcp, validateFinalApprovalForMcp, verifyCopySpecForMcp, verifyForMcp } from './mcp-tools.js';
 import { HYV_VERSION } from './version.js';
 import { loadApprovalContext } from './approval-context.js';
 
@@ -109,6 +109,36 @@ server.registerTool('hyv_apply_rewrite', {
 }, async ({ task_json, response_json, profile_json }) => {
   try {
     return json(applyRewriteForMcp(task_json, response_json, profile_json));
+  } catch (error) {
+    return failure(error);
+  }
+});
+
+server.registerTool('hyv_prepare_judgment', {
+  description: 'Prepare a versioned pre-edit or post-candidate judgment task. It does not call a model.',
+  inputSchema: {
+    stage: z.enum(['pre-edit', 'post-candidate']),
+    kind: z.enum(['triage', 'argument', 'form', 'polarity', 'flatness', 'semantic']),
+    draft: writing,
+    profile_json: profileJson,
+    candidate: writing.optional(),
+  },
+  annotations: { readOnlyHint: true },
+}, async ({ stage, kind, draft, profile_json, candidate }) => {
+  try {
+    return json(prepareJudgmentForMcp(stage, kind, draft, profile_json, candidate));
+  } catch (error) {
+    return failure(error);
+  }
+});
+
+server.registerTool('hyv_reduce_judgment', {
+  description: 'Reduce bound judgment envelopes into SHIP, EDIT, REBUILD, CLEAR, or ESCALATE. It does not call a model.',
+  inputSchema: { envelopes_json: z.string().min(1).max(250_000) },
+  annotations: { readOnlyHint: true },
+}, async ({ envelopes_json }) => {
+  try {
+    return json(reduceJudgmentForMcp(envelopes_json));
   } catch (error) {
     return failure(error);
   }

--- a/src/rewrite-task.ts
+++ b/src/rewrite-task.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'node:crypto';
-import type { CopySpec, DeterministicVerificationArtifactV1, Profile, RewriteApplyResult, RewriteEvaluation, RewriteFailure, RewriteLifecycleBindingV1, RewriteReceipt, RewriteReplacement, RewriteResponse, RewriteTask, WritingBrief } from './contracts.js';
+import type { CopySpec, DeterministicVerificationArtifactV1, HygieneRangeOperation, Profile, RewriteApplyResult, RewriteEvaluation, RewriteFailure, RewriteLifecycleBindingV1, RewriteRangeOperation, RewriteReceipt, RewriteReplacement, RewriteResponse, RewriteResponseV2, RewriteTask, WritingBrief } from './contracts.js';
 import { canonicalJson } from './canonical-json.js';
 import { parseWritingBrief } from './editorial-packs.js';
+import { hygieneSourceFindings } from './hygiene.js';
 import { analyze, deriveEditScope, renderRewritePrompt, verifyDeterministically } from './pipeline.js';
 import { sentences } from './text.js';
 
@@ -34,24 +35,47 @@ function isFailure(value: unknown): value is RewriteFailure {
   return typeof value === 'object' && value !== null && 'code' in value;
 }
 
-function parseResponse(value: unknown): RewriteResponse | RewriteFailure {
+function parseResponse(value: unknown): RewriteResponse | RewriteResponseV2 | { version: '1'; mode: 'SHIP'; taskFingerprint: string } | RewriteFailure {
   const raw = typeof value === 'string' ? parseJson(value) : value;
   if (isFailure(raw)) return raw;
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return failure('invalid_response_shape', 'Response must be an object.');
-  const response = raw as Partial<RewriteResponse>;
-  if (response.version !== '1') return failure('invalid_response_version', 'Response version must be "1".', 'version');
+  const response = raw as Record<string, unknown>;
   if (typeof response.taskFingerprint !== 'string' || response.taskFingerprint.length !== 64) return failure('invalid_response_shape', 'Response must include the task fingerprint.', 'taskFingerprint');
+  if (response.mode === 'SHIP' && response.version === '1') {
+    return { version: '1', mode: 'SHIP', taskFingerprint: response.taskFingerprint };
+  }
+  if (response.version === '2') {
+    if (!Array.isArray(response.operations)) return failure('invalid_response_shape', 'Version 2 responses require an operations array.', 'operations');
+    if (response.operations.length > MAX_REPLACEMENTS) return failure('invalid_response_shape', `Response may include at most ${MAX_REPLACEMENTS} replacements.`, 'operations');
+    for (const [index, operation] of (response.operations as RewriteRangeOperation[]).entries()) {
+      if (!operation || typeof operation !== 'object' || !Number.isInteger(operation.startSentenceId) || !Number.isInteger(operation.endSentenceId) || typeof operation.text !== 'string') {
+        return failure('invalid_response_shape', 'Every operation requires integer startSentenceId, endSentenceId, and string text.', `operations[${index}]`);
+      }
+      if (operation.endSentenceId < operation.startSentenceId) return failure('noncontiguous_range', 'A range must be inclusive and contiguous.', `operations[${index}]`);
+      if (operation.text.length > MAX_REPLACEMENT_CHARACTERS) return failure('invalid_replacement_text', `Replacement text must contain at most ${MAX_REPLACEMENT_CHARACTERS} characters.`, `operations[${index}].text`);
+    }
+    if (response.hygieneOperations !== undefined) {
+      if (!Array.isArray(response.hygieneOperations)) return failure('invalid_response_shape', 'Hygiene operations must be an array.', 'hygieneOperations');
+      for (const [index, operation] of (response.hygieneOperations as HygieneRangeOperation[]).entries()) {
+        if (!operation || !Number.isInteger(operation.start) || !Number.isInteger(operation.end) || typeof operation.text !== 'string' || operation.end < operation.start) {
+          return failure('invalid_response_shape', 'Every hygiene operation requires integer start, end, and string text.', `hygieneOperations[${index}]`);
+        }
+      }
+    }
+    return response as unknown as RewriteResponseV2;
+  }
+  if (response.version !== '1') return failure('invalid_response_version', 'Response version must be "1" or "2".', 'version');
   if (!Array.isArray(response.replacements)) return failure('invalid_response_shape', 'Response replacements must be an array.', 'replacements');
   if (response.replacements.length > MAX_REPLACEMENTS) return failure('invalid_response_shape', `Response may include at most ${MAX_REPLACEMENTS} replacements.`, 'replacements');
-  for (const [index, replacement] of response.replacements.entries()) {
-    if (!replacement || typeof replacement !== 'object' || Array.isArray(replacement) || !Number.isInteger((replacement as RewriteReplacement).sentenceId) || typeof (replacement as RewriteReplacement).text !== 'string') {
+  for (const [index, replacement] of (response.replacements as RewriteReplacement[]).entries()) {
+    if (!replacement || typeof replacement !== 'object' || Array.isArray(replacement) || !Number.isInteger(replacement.sentenceId) || typeof replacement.text !== 'string') {
       return failure('invalid_response_shape', 'Every replacement requires an integer sentenceId and string text.', `replacements[${index}]`);
     }
-    if (!(replacement as RewriteReplacement).text.trim() || (replacement as RewriteReplacement).text.length > MAX_REPLACEMENT_CHARACTERS) {
+    if (!replacement.text.trim() || replacement.text.length > MAX_REPLACEMENT_CHARACTERS) {
       return failure('invalid_replacement_text', `Replacement text must contain at most ${MAX_REPLACEMENT_CHARACTERS} characters.`, `replacements[${index}].text`);
     }
   }
-  return response as RewriteResponse;
+  return response as unknown as RewriteResponse;
 }
 
 function repairStringifiedReplacements(value: unknown): { value: unknown; adapterId?: string } {
@@ -73,11 +97,11 @@ function repairFencedJson(value: unknown): { value: unknown; adapterId?: string 
   return match ? { value: match[1], adapterId: 'fenced_json_v1' } : { value };
 }
 
-export function prepareRewriteTask(draft: string, profile: Profile, copySpec?: CopySpec, writingBrief?: WritingBrief): RewriteTask {
+export function prepareRewriteTask(draft: string, profile: Profile, copySpec?: CopySpec, writingBrief?: WritingBrief, authorizedSentenceIds: number[] = []): RewriteTask {
   const result = analyze(draft, profile, writingBrief);
   const prompt = renderRewritePrompt(draft, profile, result, [], writingBrief);
   const mapped = sentences(draft);
-  const eligibleSentenceIds = new Set(deriveEditScope(result).eligibleSentenceIds);
+  const eligibleSentenceIds = new Set([...deriveEditScope(result).eligibleSentenceIds, ...authorizedSentenceIds]);
   const taskBase = {
     version: '1' as const,
     draft,
@@ -106,6 +130,22 @@ function rejected(task: RewriteTask, raw: unknown, failures: RewriteFailure[], a
   return { status: 'repairable', failures, receipt: { version: '1', taskFingerprint: task.fingerprint, responseFingerprint: responseFingerprint(raw), adapterIds, replacementSentenceIds: [] } };
 }
 
+export function applyShip(task: RewriteTask): RewriteApplyResult {
+  return {
+    status: 'accepted',
+    candidate: task.draft,
+    failures: [],
+    receipt: {
+      version: '1',
+      taskFingerprint: task.fingerprint,
+      responseFingerprint: fingerprint({ version: '1', mode: 'SHIP', taskFingerprint: task.fingerprint }),
+      adapterIds: [],
+      replacementSentenceIds: [],
+      mode: 'SHIP',
+    },
+  };
+}
+
 export function applyRewriteResponse(task: RewriteTask, raw: unknown): RewriteApplyResult {
   const source = typeof raw === 'string' ? parseJson(raw) : raw;
   const parsed = isFailure(source) ? source : parseResponse(source);
@@ -115,6 +155,12 @@ export function applyRewriteResponse(task: RewriteTask, raw: unknown): RewriteAp
   const adapterIds = repaired.adapterId ? [repaired.adapterId] : [];
   if (isFailure(response)) return rejected(task, raw, [response], adapterIds);
   if (response.taskFingerprint !== task.fingerprint) return rejected(task, raw, [failure('task_fingerprint_mismatch', 'Response task fingerprint does not match this task.', 'taskFingerprint')], adapterIds);
+  if ('mode' in response && response.mode === 'SHIP') {
+    const shipped = applyShip(task);
+    return { ...shipped, receipt: { ...shipped.receipt, adapterIds, responseFingerprint: responseFingerprint(raw) } };
+  }
+  if (response.version === '2') return applyRangeResponse(task, response, raw, adapterIds);
+  if (!('replacements' in response)) return rejected(task, raw, [failure('invalid_response_shape', 'Response replacements must be an array.', 'replacements')], adapterIds);
   const seen = new Set<number>();
   const sentenceMap = new Map(task.sentences.map((sentence) => [sentence.id, sentence]));
   for (const [index, replacement] of response.replacements.entries()) {
@@ -131,7 +177,55 @@ export function applyRewriteResponse(task: RewriteTask, raw: unknown): RewriteAp
     const replacement = replacements.get(sentence.index);
     if (replacement !== undefined) candidate = `${candidate.slice(0, sentence.start)}${replacement}${candidate.slice(sentence.end)}`;
   }
-  return { status: 'accepted', candidate, failures: [], receipt: { version: '1', taskFingerprint: task.fingerprint, responseFingerprint: responseFingerprint(raw), adapterIds, replacementSentenceIds: [...seen].sort((left, right) => left - right) } };
+  return { status: 'accepted', candidate, failures: [], receipt: { version: '1', taskFingerprint: task.fingerprint, responseFingerprint: responseFingerprint(raw), adapterIds, replacementSentenceIds: [...seen].sort((left, right) => left - right), mode: 'EDIT' } };
+}
+
+function applyRangeResponse(task: RewriteTask, response: RewriteResponseV2, raw: unknown, adapterIds: string[]): RewriteApplyResult {
+  const sentenceMap = new Map(task.sentences.map((sentence) => [sentence.id, sentence]));
+  let previousEnd = 0;
+  for (const [index, operation] of response.operations.entries()) {
+    if (index > 0 && operation.startSentenceId <= previousEnd) return rejected(task, raw, [failure('overlapping_range', 'Operations must be ordered and non-overlapping.', `operations[${index}]`)], adapterIds);
+    if (index > 0 && operation.startSentenceId < response.operations[index - 1]!.startSentenceId) {
+      return rejected(task, raw, [failure('out_of_order_range', 'Operations must be in source order.', `operations[${index}]`)], adapterIds);
+    }
+    previousEnd = operation.endSentenceId;
+    for (let id = operation.startSentenceId; id <= operation.endSentenceId; id += 1) {
+      const sentence = sentenceMap.get(id);
+      if (!sentence) return rejected(task, raw, [failure('unknown_sentence_id', 'Range sentenceId is not in this task.', `operations[${index}]`)], adapterIds);
+      if (!sentence.eligible) return rejected(task, raw, [failure('partly_locked_range', 'A range may cover only eligible sentences.', `operations[${index}]`)], adapterIds);
+      if (id > operation.startSentenceId && !sentenceMap.has(id - 1)) return rejected(task, raw, [failure('noncontiguous_range', 'Ranges must be contiguous.', `operations[${index}]`)], adapterIds);
+    }
+  }
+  const eligibleHygiene = new Map(hygieneSourceFindings(task.draft).filter((finding) => finding.eligible).map((finding) => [`${finding.start}:${finding.end}`, finding]));
+  for (const [index, operation] of (response.hygieneOperations ?? []).entries()) {
+    if (!eligibleHygiene.has(`${operation.start}:${operation.end}`)) {
+      return rejected(task, raw, [failure('ineligible_hygiene_offset', 'Hygiene changes require an eligible source-offset finding.', `hygieneOperations[${index}]`)], adapterIds);
+    }
+  }
+  let candidate = task.draft;
+  for (const operation of [...(response.hygieneOperations ?? [])].sort((left, right) => right.start - left.start)) {
+    candidate = `${candidate.slice(0, operation.start)}${operation.text}${candidate.slice(operation.end)}`;
+  }
+  const mapped = sentences(candidate);
+  for (const operation of [...response.operations].reverse()) {
+    const start = mapped.find((sentence) => sentence.index === operation.startSentenceId);
+    const end = mapped.find((sentence) => sentence.index === operation.endSentenceId);
+    if (!start || !end) return rejected(task, raw, [failure('unknown_sentence_id', 'Range sentenceId is not in this task.', 'operations')], adapterIds);
+    candidate = `${candidate.slice(0, start.start)}${operation.text}${candidate.slice(end.end)}`;
+  }
+  return {
+    status: 'accepted',
+    candidate,
+    failures: [],
+    receipt: {
+      version: '1',
+      taskFingerprint: task.fingerprint,
+      responseFingerprint: responseFingerprint(raw),
+      adapterIds,
+      operationRanges: response.operations.map((operation) => ({ startSentenceId: operation.startSentenceId, endSentenceId: operation.endSentenceId })),
+      mode: 'EDIT',
+    },
+  };
 }
 
 export function evaluateRewriteResponse(task: RewriteTask, raw: unknown, profile: Profile): RewriteEvaluation {


### PR DESCRIPTION
## Summary
- Adds a versioned judgment envelope for pre-edit triage/argument/form and post-candidate argument/polarity/form/flatness/semantic review.
- Range rewrite v2 supports ordered contiguous sentence replacement, deletion, and adjacent merge. SHIP returns original bytes. Hygiene edits require eligible source-offset findings.
- CLI (`prepare-judgment`, `reduce-judgment`) and MCP (`hyv_prepare_judgment`, `hyv_reduce_judgment`) keep the same artifacts.

## Checkpoint status
- MAR-362 remains unpassed. This PR is MAR-363 / plan unit U8 only.
- Founder asked to start this work without a writer study. The evaluator still rejects `PROCEED_TO_MAR_363`.
- MAR-364 and MAR-365 were not started.

## Test plan
- [x] `npm test` (233 passing)
- [x] `npm run check:release`
- [ ] CI `verify` on this PR
- [ ] SHIP returns original draft bytes
- [ ] Overlapping or partly locked ranges fail before a candidate exists
- [ ] Unbounded argument failure reduces only to REBUILD


Made with [Cursor](https://cursor.com)