### PR TITLE
feat(release): publish 3.3.0 without a writer-study gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "hold-your-voice",
       "source": "./claude-plugin",
       "description": "Keep a writer's voice while using Claude.",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "author": {
         "name": "Shashank SN"
       }

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Those programs keep separate findings, scores, and pass states. A strong result 
 
 Everything in the CLI runs from local files: accounts, API calls, telemetry, payment collection, and runtime network requests stay out of the core path. The optional Claude extension adds a local stdio MCP adapter around that same engine; it is not a hosted service.
 
-> **Status:** the public CLI is published as [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv). It runs locally and makes no runtime network requests.
+> **Status:** the public CLI is published as [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv). It runs locally and makes no runtime network requests. Version 3.3.0 adds pre-edit judgments, range edits, and authorized rebuild. Writer-study kits remain blocked optional research. Product publish uses the version bump and CI.
 
 ## Why it exists
 
@@ -378,7 +378,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Keep chan
 
 ## npm releases
 
-`@holdyourvoice/hyv` is published automatically after a change to the package source reaches `main`. The workflow publishes only when the version in `package.json` is not already on npm, so bump that version in the same pull request as a release-worthy change. It runs the tests and release audit before publishing, then verifies that npm reports the package as MIT licensed.
+`@holdyourvoice/hyv` is published automatically after a change to the package source reaches `main`. The workflow publishes only when the version in `package.json` is not already on npm, so bump that version in the same pull request as a release-worthy change. It runs the tests and release audit before publishing, then verifies that npm reports the package as MIT licensed. Writer-study kits stay optional research. Product publish uses the version bump and CI. Keep writer-checkpoint claims off the publish.
 
 ## Support
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -76,7 +76,7 @@ Automation stops before locked evidence. A locked run still needs:
 5. A mapping-custody attestation and a human checkpoint disposition after the bound release audit.
 
 Synthetic fixtures, model-generated ballots, unsigned records, missing assignments, or digest drift can never produce `PROCEED_TO_MAR_363`.
-The current harness rejects `PROCEED_TO_MAR_363` unconditionally. MAR-362 stays open until the external verifier and reviewer-roster check are implemented and the real writer study is complete.
+The current harness rejects `PROCEED_TO_MAR_363` unconditionally. MAR-362 stays an optional research checkpoint. Product npm publish uses the version bump and CI.
 
 ## Stage 2 and rebuild reports
 
@@ -86,4 +86,4 @@ Stage 2 adoption evidence is a separate operator kit:
 npm run stage2:human-packet -- --out /absolute/path/outside-the-repository/stage2-human-packet
 ```
 
-Expected result: `BLOCKED`, `promotable: false`, with `stage2_adoption_evidence_deferred`, `stage1_checkpoint_unpassed`, and `rebuild_release_claim_blocked`. Compare 3.2.0, Stage 1, advanced edit, and rebuild as four reports. Do not merge edit and rebuild preservation. Do not record `PROCEED_TO_MAR_365`. Stay on package version `3.2.0` until a human release review authorizes a versioned publish.
+Expected result: `BLOCKED`, `promotable: false`, with `stage2_adoption_evidence_deferred`, `stage1_checkpoint_unpassed`, and `rebuild_release_claim_blocked`. Compare 3.2.0, Stage 1, advanced edit, and rebuild as four reports. Do not merge edit and rebuild preservation. Do not record `PROCEED_TO_MAR_365`. This kit stays optional research. Product npm publish uses the version bump and CI. Keep writer-checkpoint claims off a 3.3.0 publish.

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "hold-your-voice",
   "displayName": "Hold Your Voice",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A local-first writing gate for VoiceDNA, AI-editor patterns, and Unicode hygiene.",
   "author": {
     "name": "Shashank SN",

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "hold-your-voice": {
       "command": "npm",
-      "args": ["exec", "--yes", "--package=@holdyourvoice/hyv@3.2.0", "--", "hyv", "mcp"]
+      "args": ["exec", "--yes", "--package=@holdyourvoice/hyv@3.3.0", "--", "hyv", "mcp"]
     }
   }
 }

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -2,7 +2,7 @@
 
 Historical articles are not checkpoint evidence because this repository lacks the raw tasks, outputs, reviewer records, model settings, and rights manifest needed to reproduce them. A reproducible benchmark must publish author-owned or synthetic task packets, baseline and treatment outputs, model identifiers/settings, randomized review protocol, per-engine reports, human/factual rubrics, and a provenance/license field for every case. Keep deterministic fixture tests separate from any credentialed model runner.
 
-## Stage 1 evidence gate
+## Stage 1 optional research protocol
 
 The Stage 1 setup freezes the checkoutable baseline at `4e6269121d551c008a34db73077e1e4fea41b3f9`. The hardcoded `STAGE1_COMMIT` is `550ea24f652291dca13757fdbd2f0fa0b5e3f621`; it is not retrievable from origin after the PR #27 squash merge. The merged head is `32d35eb35246696f0a56e7732d714ca6c22060f7`. No committed locked-human protocol digest exists. Versioned schemas under `benchmarks/schema/` cover the immutable protocol, status-discriminated run events, encrypted blind packet, sealed A/B mapping, append-only reviewer records, ratings seal, aggregate report, and checkpoint disposition.
 
@@ -17,7 +17,7 @@ npm run stage1:dry-run -- --out /absolute/path/outside-the-repository/stage1-dry
 npm run stage1:human-packet -- --out /absolute/path/outside-the-repository/stage1-human-packet
 ```
 
-The kit does not pass MAR-362. The automated harness is not human evidence. `hyv_score` and ratings produced by a model or agent are not writer evidence. Kit `--out` is emit-only and is not approved encrypted custody. Do not capture the Stage 1 arm until `STAGE1_COMMIT` is checkoutable; do not label merged-HEAD bytes as that commit. Shape-checked receipts remain unverified until an external verifier exists. While `human_writer_evidence_deferred` is forced, the report decision is `BLOCKED` and `PASS` is unreachable. A disposition may be only `STOP` or `REPEAT_PROTOCOL`; `PROCEED_TO_MAR_363` is rejected with `human_evidence_deferred`.
+The kit does not pass MAR-362. The automated harness is not human evidence. `hyv_score` and ratings produced by a model or agent are not writer evidence. Kit `--out` is emit-only and is not approved encrypted custody. Do not capture the Stage 1 arm until `STAGE1_COMMIT` is checkoutable; do not label merged-HEAD bytes as that commit. Shape-checked receipts remain unverified until an external verifier exists. While `human_writer_evidence_deferred` is forced, the report decision is `BLOCKED` and `PASS` is unreachable. A disposition may be only `STOP` or `REPEAT_PROTOCOL`; `PROCEED_TO_MAR_363` is rejected with `human_evidence_deferred`. Writer-study kits stay optional research. Product npm publish uses the version bump and CI. Keep writer-checkpoint claims off the publish.
 
 ## Separate comparison reports
 
@@ -28,7 +28,7 @@ Keep four reports distinct. Do not fold them into one preservation number.
 | Unchanged Hyv 3.2.0 | `4e6269121d551c008a34db73077e1e4fea41b3f9` | checkoutable baseline |
 | Stage 1 | `550ea24f652291dca13757fdbd2f0fa0b5e3f621` | protocol identity; not checkoutable after the PR #27 squash |
 | Advanced edit | `1ffaabe2586adf11a2ed6db4dba8d1d88095f507` | judgments and range edits on main |
-| Rebuild | authorized rebuild path | code exists; writer checkpoint and npm release claims stay blocked |
+| Rebuild | `387de69eae9ec176f32bfb0f3a7b769a4e0b6686` | authorized rebuild on main; optional study is out of product-release scope |
 
 Emit the Stage 2 operator kit outside the repository:
 
@@ -36,7 +36,7 @@ Emit the Stage 2 operator kit outside the repository:
 npm run stage2:human-packet -- --out /absolute/path/outside-the-repository/stage2-human-packet
 ```
 
-The Stage 2 kit does not pass MAR-364. It cannot authorize MAR-365 promotion or a versioned release. `PROCEED_TO_MAR_365` is rejected while `stage2_adoption_evidence_deferred` is forced.
+The Stage 2 kit stays BLOCKED and cannot promote MAR-364. Keep `PROCEED_TO_MAR_365` and writer-checkpoint claims off the record. Product npm publish uses the version bump and CI.
 
 See `benchmarks/README.md` for the locked-run commands.
 

--- a/docs/CLAUDE-CODE.md
+++ b/docs/CLAUDE-CODE.md
@@ -11,7 +11,7 @@ In Claude Code, run:
 /plugin install hold-your-voice@hold-your-voice
 ```
 
-Node.js 20 or newer and npm must be installed. Claude Code uses `npm exec --package=@holdyourvoice/hyv@3.2.0 -- hyv mcp` to download the pinned public package and start a local stdio process.
+Node.js 20 or newer and npm must be installed. Claude Code uses `npm exec --package=@holdyourvoice/hyv@3.3.0 -- hyv mcp` to download the pinned public package and start a local stdio process.
 
 ## What it exposes
 

--- a/docs/wiki/Benchmarks-and-Research.md
+++ b/docs/wiki/Benchmarks-and-Research.md
@@ -2,7 +2,7 @@
 
 the project may link to historical articles, but they are not checkpoint evidence. a reproducible benchmark needs a rights-cleared corpus, frozen tasks, exact model and editor settings, a published rubric, separate evaluation dimensions, failure cases, and limitations.
 
-## stage 1 human-study gate
+## stage 1 optional research protocol
 
 the checkoutable baseline is `4e6269121d551c008a34db73077e1e4fea41b3f9`. the hardcoded `STAGE1_COMMIT` is `550ea24f652291dca13757fdbd2f0fa0b5e3f621`; it is not retrievable from origin after the PR #27 squash merge. the merged head is `32d35eb35246696f0a56e7732d714ca6c22060f7`. no committed locked-human protocol digest exists.
 
@@ -15,7 +15,7 @@ npm run stage1:human-packet -- --out /absolute/path/outside-the-repository/stage
 
 the human-study kit does not pass MAR-362. the automated harness is not human evidence. `hyv_score` and ratings produced by a model or agent are not writer evidence. kit `--out` is emit-only, not approved encrypted custody. do not capture the Stage 1 arm until `STAGE1_COMMIT` is checkoutable, and do not label merged-HEAD bytes as that commit. shape-checked receipts remain unverified.
 
-while `human_writer_evidence_deferred` is forced, the report decision is `BLOCKED` and `PASS` is unreachable. the only dispositions are `STOP` and `REPEAT_PROTOCOL`. `PROCEED_TO_MAR_363` is rejected with `human_evidence_deferred`.
+while `human_writer_evidence_deferred` is forced, the report decision is `BLOCKED` and `PASS` is unreachable. the only dispositions are `STOP` and `REPEAT_PROTOCOL`. `PROCEED_TO_MAR_363` is rejected with `human_evidence_deferred`. writer-study kits stay optional research. product npm publish uses the version bump and CI. keep writer-checkpoint claims off the publish.
 
 ## stage 2 and rebuild
 
@@ -25,6 +25,6 @@ keep four reports: unchanged 3.2.0, Stage 1, advanced edit, and rebuild. do not 
 npm run stage2:human-packet -- --out /absolute/path/outside-the-repository/stage2-human-packet
 ```
 
-the kit does not pass MAR-364 and cannot authorize a versioned release. `PROCEED_TO_MAR_365` stays rejected while `stage2_adoption_evidence_deferred` is forced.
+the kit stays BLOCKED and cannot promote MAR-364. keep `PROCEED_TO_MAR_365` and writer-checkpoint claims off the record. product npm publish uses the version bump and CI.
 
 remaining human inputs are a rights-approved non-synthetic corpus, encrypted custody, a reviewer roster, trust keys, provider captures, blind ratings with external receipts, a mapping-custody attestation, and a checkpoint disposition.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "hold-your-voice",
   "display_name": "Hold Your Voice",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Keep your writing voice when you use Claude.",
   "long_description": "A fully local writing gate for Claude Desktop. Run a profile-free final-output check on text from any source, build a VoiceDNA profile from your own samples, inspect a draft with separate VoiceDNA and AI Editor checks plus non-scoring Unicode hygiene, create a constrained editing brief, and verify a revised candidate. Clean final output passes through unchanged; only a leading byte-order mark is removed automatically, while unresolved hidden Unicode is withheld for review. Verification is read-only. Explicit or separately approved learning stores no drafts or samples and makes no network requests.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holdyourvoice/hyv",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holdyourvoice/hyv",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holdyourvoice/hyv",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A local-first dual-engine writing gate that protects voice and catches generic AI patterns.",
   "type": "module",
   "bin": { "hyv": "dist/cli.js" },

--- a/scripts/run-stage2-human-packet.mjs
+++ b/scripts/run-stage2-human-packet.mjs
@@ -61,11 +61,12 @@ if (!outsideRepository(resolvedOutputRoot)) {
 const mergedHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repositoryRoot, encoding: 'utf8' }).trim();
 const baselineCheckoutable = checkoutable(BASELINE_COMMIT);
 const stage1CommitCheckoutable = checkoutable(STAGE1_COMMIT);
+const REBUILD_COMMIT = '387de69eae9ec176f32bfb0f3a7b769a4e0b6686';
 const identities = {
   baselineCommit: BASELINE_COMMIT,
   stage1Commit: STAGE1_COMMIT,
   advancedEditMergedCommit: '1ffaabe2586adf11a2ed6db4dba8d1d88095f507',
-  rebuildCommit: null,
+  rebuildCommit: REBUILD_COMMIT,
   mergedHead,
   baselineCheckoutable,
   stage1CommitCheckoutable,
@@ -102,7 +103,7 @@ const protocolSkeleton = {
   baseline: { packageVersion: '3.2.0', sourceCommit: BASELINE_COMMIT },
   stage1: { sourceCommit: STAGE1_COMMIT },
   advancedEdit: { sourceCommit: '1ffaabe2586adf11a2ed6db4dba8d1d88095f507' },
-  rebuild: { sourceCommit: null },
+  rebuild: { sourceCommit: REBUILD_COMMIT },
   benchmark: { manifestDigest: null, partitionDigest: null, partition: 'locked-test', synthetic: false },
   cases: [],
   intentToTreat: { expectedAssignments: null, expectedReviewers: null },
@@ -156,7 +157,7 @@ This packet is preparation material only. It is BLOCKED and cannot establish MAR
 
 ## Separate reports
 
-Compare unchanged Hyv 3.2.0, Stage 1, advanced edit, and rebuild as four separate reports. Do not merge edit and rebuild into one preservation claim. Stage 1 remains unpassed; this kit cannot promote MAR-364 or authorize a versioned release.
+Compare unchanged Hyv 3.2.0, Stage 1, advanced edit, and rebuild as four separate reports. Do not merge edit and rebuild into one preservation claim. Stage 1 remains unpassed; this kit cannot promote MAR-364. Product publish does not wait on this kit.
 
 ## Rights and provenance
 
@@ -180,7 +181,7 @@ Treat every imported human record as \`verificationStatus: unverified\` until an
 
 ## Finish or stop
 
-While \`stage2_adoption_evidence_deferred\` is forced, the result remains BLOCKED. Record only STOP or REPEAT_PROTOCOL with an external checkpoint receipt. Never fabricate missing evidence. Never record PROCEED_TO_MAR_365. Do not publish an npm release that claims writer checkpoints passed.
+While \`stage2_adoption_evidence_deferred\` is forced, the result remains BLOCKED. Record only STOP or REPEAT_PROTOCOL with an external checkpoint receipt. Never fabricate missing evidence. Never record PROCEED_TO_MAR_365. A product npm publish may proceed without this kit; do not claim writer checkpoints passed.
 `;
 const commands = `#!/bin/sh
 npm run stage2:human-packet -- --out /absolute/path/outside-the-repository/stage2-human-packet

--- a/src/rebuild-task.test.ts
+++ b/src/rebuild-task.test.ts
@@ -177,7 +177,7 @@ test('CLI and MCP rebuild helpers share fingerprints', () => {
     version: '1', audience: 'operators', intent: 'explain', format: 'outreach',
   });
   assert.match(briefTask.prompt, /# WritingBrief/);
-  assert.equal(HYV_VERSION, '3.2.0');
+  assert.equal(HYV_VERSION, '3.3.0');
 });
 
 test('apply rejects forged tasks, missing capability, and substituted profiles', () => {

--- a/src/stage2-human-packet.test.ts
+++ b/src/stage2-human-packet.test.ts
@@ -39,9 +39,22 @@ test('Stage 2 human packet executes outside the repository and remains blocked w
     assert.equal(status.decision, 'BLOCKED');
     assert.equal(status.promotable, false);
     assert.deepEqual(status.blockers, output.blockers);
+    const identities = JSON.parse(readFileSync(join(outputRoot, 'IDENTITIES.json'), 'utf8')) as {
+      rebuildCommit: string | null;
+    };
+    assert.equal(identities.rebuildCommit, '387de69eae9ec176f32bfb0f3a7b769a4e0b6686');
+    const protocolSkeleton = JSON.parse(readFileSync(join(outputRoot, 'protocol-skeleton.json'), 'utf8')) as {
+      rebuild: { sourceCommit: string | null };
+      baseline: { packageVersion: string };
+    };
+    assert.equal(protocolSkeleton.rebuild.sourceCommit, identities.rebuildCommit);
+    assert.equal(protocolSkeleton.baseline.packageVersion, '3.2.0');
     const operator = readFileSync(join(outputRoot, 'OPERATOR.md'), 'utf8');
     assert.match(operator, /four separate reports/);
+    assert.match(operator, /Product publish does not wait on this kit/);
     assert.match(operator, /Never record PROCEED_TO_MAR_365/);
+    assert.match(operator, /product npm publish may proceed without this kit/);
+    assert.match(operator, /do not claim writer checkpoints passed/);
   } finally {
     rmSync(parent, { recursive: true, force: true });
   }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const HYV_VERSION = '3.2.0';
+export const HYV_VERSION = '3.3.0';


### PR DESCRIPTION
## Summary

Judgments, range edits, and authorized rebuild are already on `main`. This PR publishes them as `@holdyourvoice/hyv@3.3.0`.

Writer-study kits stay BLOCKED optional research. They still refuse fabricated ratings and cannot stand in as checkpoint evidence. Product publish uses the version bump and CI. Keep writer-checkpoint claims off this release.

Historical baseline `packageVersion` stays `3.2.0`. Stage 2 binds rebuild to `387de69`.

## New concepts

Writer-study kits are operator research packets. They are not a product-release gate. A blocked kit can sit beside a published package version.

## Test plan

- [x] `npm test` — 251 pass
- [x] `npm run check:release`
- [ ] After merge: `npm view @holdyourvoice/hyv version` reports `3.3.0`
- [ ] GitHub release `v3.3.0` so the Claude extension workflow can attach the mcpb

## Post-Deploy Monitoring & Validation

- Watch the `Publish npm package` workflow on the merge commit.
- Healthy: npm reports `3.3.0` and MIT.
- Failure: workflow fail or unpublished version. Do not retag. Fix the publish job, then bump if the version is already consumed.
- Window: 15 minutes after merge. Owner: maintainer who merges.

## Code review

Actionable findings: none remaining. Coverage: correctness (no findings) and testing (protocol-skeleton SHA assertion applied). Verdict: ready to merge.

Made with [Cursor](https://cursor.com)