### PR TITLE
docs: document the founder-aware rewrite

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Those programs keep separate findings, scores, and pass states. A strong result 
 
 Everything in the CLI runs from local files: accounts, API calls, telemetry, payment collection, and runtime network requests stay out of the core path. The optional Claude extension adds a local stdio MCP adapter around that same engine; it is not a hosted service.
 
-> **Status:** the public CLI is published as [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv). It runs locally and makes no runtime network requests. Version 3.3.0 adds pre-edit judgments, range edits, and authorized rebuild. Writer-study kits remain blocked optional research. Product publish uses the version bump and CI.
+> **Status:** [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) **3.3.0** is the public founder-aware rewrite. It runs locally and makes no runtime network requests. The package includes Profile v3 policy, pre-edit SHIP/EDIT/REBUILD judgments, contiguous range edits, authorized rebuild, and a signed semantic lifecycle.
 
 ## Why it exists
 
@@ -27,6 +27,7 @@ Hold Your Voice keeps the work visible:
 | Does the draft still resemble this writer’s observable mechanics? | VoiceDNA | A profile-based score, findings, and pass state. |
 | Does the draft contain a configured editorial pattern worth inspecting? | AI Editor | A rule-based score, sentence findings, and pass state. |
 | Did the rewrite introduce a new blocker or replace too much? | Verification | Regressions, preservation score, and a release decision. |
+| Should this draft ship, take a bounded edit, or rebuild? | Judgment | A SHIP, EDIT, or REBUILD recommendation bound to the draft and profile. |
 
 Its scope is a local writing gate. Authorship detection, fact checking, plagiarism review, and hosted generation each need their own tools. Hold Your Voice gives a writer or chosen model a narrow editing brief, then asks the same two engines to inspect the result.
 
@@ -228,7 +229,27 @@ flowchart LR
   G --> R[Pass or inspect regressions]
 ```
 
-The tool never applies changes to your draft. You decide which findings are valid, apply replacement sentences deliberately, and run the final check.
+The tool never applies changes to your draft. You decide which findings are valid, apply replacement sentences or an authorized rebuild deliberately, and run the final check.
+
+## Founder-aware rewrite
+
+3.3.0 keeps the original analyze → brief → verify loop and adds a structured rewrite path.
+
+1. Prepare a pre-edit judgment. Findings reduce to **SHIP**, bounded **EDIT**, or **REBUILD**.
+2. **SHIP** returns the original bytes. No model call.
+3. **EDIT** applies eligible sentence replacements or contiguous range edits through `prepare-rewrite` / `apply-rewrite`. Clean and unflagged text stays in place. Overlapping, out-of-order, or partly locked ranges fail before a candidate is built.
+4. **REBUILD** prepares a whole-document candidate only after a matching REBUILD recommendation, a CopySpec, and a signed `hyv.rebuild-authorization` capability. `prepare-rebuild` / `apply-rebuild` re-check that capability and the bound profile. Claim, polarity, hygiene, and semantic gates stay in force. Edit and rebuild responses are mutually incompatible.
+
+```bash
+hyv prepare-judgment pre-edit argument draft.md profile.json task.json
+hyv reduce-judgment envelope-a.json envelope-b.json envelope-c.json
+hyv prepare-rewrite draft.md profile.json task.json
+hyv apply-rewrite task.json response.json profile.json
+hyv prepare-rebuild draft.md profile.json reduction.json copy-spec.json task.json --capability-file capability.json
+hyv apply-rebuild task.json response.json profile.json --capability-file capability.json
+```
+
+CLI and MCP expose the same contracts. The engine never calls a model. An editor or chosen model still sits outside the package.
 
 ## The five rewrite tiers
 
@@ -240,7 +261,7 @@ The prompt has an order. Lower tiers can refine a higher tier; they cannot overr
 4. **Tier 3: AI Editor.** Inspect yellow findings. Change a line only when the repair helps.
 5. **Tier 4: output.** Return replacement sentences keyed by sentence number.
 
-This order protects meaning before style. Read the complete [prompt contract](docs/PROMPT-CONTRACT.md) before changing it.
+This order protects meaning before style. Rebuild is a separate whole-document contract; it does not use sentence-number replacements. Read the complete [prompt contract](docs/PROMPT-CONTRACT.md) before changing either path.
 
 ## VoiceDNA: 13 observable elements
 
@@ -302,8 +323,12 @@ The preservation score is a guardrail based on retained original words longer th
 | `hyv hygiene <draft> [--fix] [--output=path]` | Draft | Hygiene report or cleaned copy plus receipt | You need to inspect or conservatively clean hidden Unicode. |
 | `hyv final-check <path\|->` | Any final text | Exact accepted text on stdout or a withheld-output report on stderr | Text is about to cross a user-facing boundary. |
 | `hyv rewrite-prompt <draft> <profile.json>` | Draft and profile | Markdown editing brief | You need a constrained request for an editor or model. |
-| `hyv prepare-rewrite <draft> <profile.json> <task.json>` | Draft and profile | Versioned task file plus metadata | A host needs a fingerprint-bound sentence-edit task. |
+| `hyv prepare-rewrite <draft> <profile.json> <task.json>` | Draft and profile | Versioned task file plus metadata | A host needs a fingerprint-bound sentence-edit or range-edit task. |
 | `hyv apply-rewrite <task.json> <response.json> <profile.json>` | Task, response, and profile | Candidate evaluation JSON | A host needs to apply and recheck eligible sentence replacements. |
+| `hyv prepare-judgment <pre-edit\|post-candidate> <kind> <draft> <profile.json> <task.json> [candidate.md]` | Draft, profile, and optional candidate | Versioned judgment task | Findings need a SHIP, EDIT, or REBUILD recommendation. |
+| `hyv reduce-judgment <envelope.json> <envelope.json> [envelope.json...]` | Signed judgment envelopes | Recommendation JSON | Multiple judgment envelopes must reduce to one decision. |
+| `hyv prepare-rebuild <draft> <profile.json> <reduction.json> <copy-spec.json> <task.json>` | Draft, recommendation, CopySpec, and capability | Versioned rebuild task | An upstream REBUILD recommendation needs a whole-document candidate. |
+| `hyv apply-rebuild <task.json> <response.json> <profile.json>` | Task, response, profile, and capability | Candidate evaluation JSON | A host needs to apply and recheck an authorized rebuild. |
 | `hyv verify <original> <candidate> <profile.json>` | Original, candidate, profile | Verification JSON and exit code | You need the candidate gate. |
 | `hyv verify-spec <original> <candidate> <profile.json> <copy-spec.json>` | Original, candidate, profile, CopySpec | Verification JSON with hard claim gate | A brief contains locked facts or prohibited claims. |
 | `hyv learning <show\|inspect\|add\|record\|ratify\|supersede\|migrate\|clear> ...` | Profile, operation value, and bounded metadata options | Preferences or a text-free mutation receipt | You need to inspect, migrate, or manage profile-scoped learning. |
@@ -314,7 +339,7 @@ Every file argument can be `-` when the command accepts text input from standard
 
 Profile v3 learning is keyed by its stable local profile ID, so compatible history survives profile revisions. `record`, `ratify`, and `supersede` accept bounded `--mutation-id`, `--authority`, `--provenance`, `--weight`, and `--compatibility` options. `ratify` and `supersede` require Profile v3. `migrate` explicitly copies compatible legacy Profile v2 learning into one Profile v3 identity. Replaying an identical mutation is idempotent; reusing its ID for a different operation returns a conflict. Inspection and receipts expose event metadata only, never stored instructions or draft text.
 
-The standalone CLI supports normal-policy semantic review. High-assurance review requires a trusted embedding and is rejected by the CLI. Approval capabilities are accepted only through `--capability-stdin` or a permission-checked `--capability-file`; adapters validate capabilities but never mint them. Rejection needs no capability. Approval and `learning record-approved` require the matching signed final-approval capability. `apply-rewrite`, `lifecycle submit-verdict`, and `lifecycle finalize` exit `2` when the candidate or transition is not accepted, while usage and runtime failures exit `1`.
+The standalone CLI supports normal-policy semantic review. High-assurance review requires a trusted embedding and is rejected by the CLI. Approval and rebuild capabilities are accepted only through `--capability-stdin` or a permission-checked `--capability-file`; adapters validate capabilities but never mint them. Rejection needs no capability. Approval and `learning record-approved` require the matching signed final-approval capability. `apply-rewrite`, `apply-rebuild`, `lifecycle submit-verdict`, and `lifecycle finalize` exit `2` when the candidate or transition is not accepted, while usage and runtime failures exit `1`.
 
 ## Project map
 
@@ -328,7 +353,9 @@ The standalone CLI supports normal-policy semantic review. High-assurance review
 | `src/editorial-packs.ts` | Parses WritingBrief context and runs format and batch checks. |
 | `src/learning.ts` | Stores text-free, profile-scoped verified repairs and composes bounded local preferences. |
 | `src/pipeline.ts` | Combines scored pass states, makes briefs, and verifies candidates. |
-| `src/rewrite-task.ts` | Prepares and evaluates fingerprint-bound sentence-replacement tasks. |
+| `src/rewrite-task.ts` | Prepares and evaluates fingerprint-bound sentence-replacement and range-edit tasks. |
+| `src/judgment-task.ts` | Reduces pre-edit SHIP/EDIT/REBUILD recommendations and post-candidate clearance. |
+| `src/rebuild-task.ts` | Prepares whole-document rebuild after a matching recommendation, CopySpec, and signed capability. |
 | `src/semantic-review.ts` | Defines and reduces semantic and human-review lifecycle artifacts. |
 | `src/approval-capability.ts` | Verifies canonical signed approval capabilities. |
 | `src/approval-context.ts` | Loads permission-checked trust roots and evaluator authorization. |
@@ -378,7 +405,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Keep chan
 
 ## npm releases
 
-`@holdyourvoice/hyv` is published automatically after a change to the package source reaches `main`. The workflow publishes only when the version in `package.json` is not already on npm, so bump that version in the same pull request as a release-worthy change. It runs the tests and release audit before publishing, then verifies that npm reports the package as MIT licensed. Writer-study kits stay optional research. Product publish uses the version bump and CI. Keep writer-checkpoint claims off the publish.
+`@holdyourvoice/hyv` is published automatically after a change to the package source reaches `main`. The workflow publishes only when the version in `package.json` is not already on npm, so bump that version in the same pull request as a release-worthy change. It runs the tests and release audit before publishing, then verifies that npm reports the package as MIT licensed.
 
 ## Support
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,42 +1,27 @@
 # Benchmarks and historical results
 
-Historical articles are not checkpoint evidence because this repository lacks the raw tasks, outputs, reviewer records, model settings, and rights manifest needed to reproduce them. A reproducible benchmark must publish author-owned or synthetic task packets, baseline and treatment outputs, model identifiers/settings, randomized review protocol, per-engine reports, human/factual rubrics, and a provenance/license field for every case. Keep deterministic fixture tests separate from any credentialed model runner.
+Historical articles sit beside a frozen Hyv 3.2.0 baseline at `4e6269121d551c008a34db73077e1e4fea41b3f9`. Treat the articles as dated product writing. A reproducible comparison still needs a rights-cleared corpus, frozen tasks, exact model and editor settings, a published rubric, separate evaluation dimensions, failure cases, and limitations. Keep deterministic fixture tests separate from any credentialed model runner.
 
-## Stage 1 optional research protocol
-
-The Stage 1 setup freezes the checkoutable baseline at `4e6269121d551c008a34db73077e1e4fea41b3f9`. The hardcoded `STAGE1_COMMIT` is `550ea24f652291dca13757fdbd2f0fa0b5e3f621`; it is not retrievable from origin after the PR #27 squash merge. The merged head is `32d35eb35246696f0a56e7732d714ca6c22060f7`. No committed locked-human protocol digest exists. Versioned schemas under `benchmarks/schema/` cover the immutable protocol, status-discriminated run events, encrypted blind packet, sealed A/B mapping, append-only reviewer records, ratings seal, aggregate report, and checkpoint disposition.
-
-Every locked assignment stays in the intent-to-treat denominator. Timeouts, abandonment, and hard-gate failures are failures; they are never silently rerun or converted into preference ballots. Reports reconcile planned, completed, missing, failed, timed-out, and abandoned assignments and bind every artifact through canonical SHA-256 digests. Synthetic development and calibration fixtures always reduce to `BLOCKED` and cannot support a promotion claim.
-
-Human evidence is external to automation. Remaining inputs are a rights-approved non-synthetic corpus, encrypted custody, a reviewer roster, trust keys, provider captures, blind ratings with external receipts, a mapping-custody attestation, and a checkpoint disposition. Private source and blind candidates stay in approved encrypted custody. Exported artifacts contain digests and categorical ratings only. The current evaluator validates receipt shape and artifact bindings but deliberately blocks cryptographic trust and reviewer-roster acceptance until an external verifier is configured.
-
-Run the automated dry-run and emit the human-study kit outside the repository:
-
-```bash
-npm run stage1:dry-run -- --out /absolute/path/outside-the-repository/stage1-dry-run
-npm run stage1:human-packet -- --out /absolute/path/outside-the-repository/stage1-human-packet
-```
-
-The kit does not pass MAR-362. The automated harness is not human evidence. `hyv_score` and ratings produced by a model or agent are not writer evidence. Kit `--out` is emit-only and is not approved encrypted custody. Do not capture the Stage 1 arm until `STAGE1_COMMIT` is checkoutable; do not label merged-HEAD bytes as that commit. Shape-checked receipts remain unverified until an external verifier exists. While `human_writer_evidence_deferred` is forced, the report decision is `BLOCKED` and `PASS` is unreachable. A disposition may be only `STOP` or `REPEAT_PROTOCOL`; `PROCEED_TO_MAR_363` is rejected with `human_evidence_deferred`. Writer-study kits stay optional research. Product npm publish uses the version bump and CI. Keep writer-checkpoint claims off the publish.
+Versioned schemas under `benchmarks/schema/` cover the immutable protocol, status-discriminated run events, encrypted blind packet, sealed A/B mapping, append-only reviewer records, ratings seal, aggregate report, and checkpoint disposition. Every locked assignment stays in the intent-to-treat denominator. Timeouts, abandonment, and hard-gate failures are failures. Reports bind every artifact through canonical SHA-256 digests.
 
 ## Separate comparison reports
 
 Keep four reports distinct. Do not fold them into one preservation number.
 
-| Arm | Identity | Current report |
+| Arm | Identity | What it is |
 |---|---|---|
-| Unchanged Hyv 3.2.0 | `4e6269121d551c008a34db73077e1e4fea41b3f9` | checkoutable baseline |
-| Stage 1 | `550ea24f652291dca13757fdbd2f0fa0b5e3f621` | protocol identity; not checkoutable after the PR #27 squash |
-| Advanced edit | `1ffaabe2586adf11a2ed6db4dba8d1d88095f507` | judgments and range edits on main |
-| Rebuild | `387de69eae9ec176f32bfb0f3a7b769a4e0b6686` | authorized rebuild on main; optional study is out of product-release scope |
+| Unchanged Hyv 3.2.0 | `4e6269121d551c008a34db73077e1e4fea41b3f9` | Frozen comparison baseline |
+| Stage 1 | `32d35eb35246696f0a56e7732d714ca6c22060f7` | Founder-aware Stage 1 on main |
+| Advanced edit | `1ffaabe2586adf11a2ed6db4dba8d1d88095f507` | Judgments and range edits |
+| Rebuild | `387de69eae9ec176f32bfb0f3a7b769a4e0b6686` | Authorized rebuild |
 
-Emit the Stage 2 operator kit outside the repository:
+Maintainer packets emit outside the repository:
 
 ```bash
+npm run stage1:dry-run -- --out /absolute/path/outside-the-repository/stage1-dry-run
+npm run stage1:human-packet -- --out /absolute/path/outside-the-repository/stage1-human-packet
 npm run stage2:human-packet -- --out /absolute/path/outside-the-repository/stage2-human-packet
 ```
-
-The Stage 2 kit stays BLOCKED and cannot promote MAR-364. Keep `PROCEED_TO_MAR_365` and writer-checkpoint claims off the record. Product npm publish uses the version bump and CI.
 
 See `benchmarks/README.md` for the locked-run commands.
 

--- a/docs/wiki/Benchmarks-and-Research.md
+++ b/docs/wiki/Benchmarks-and-Research.md
@@ -1,30 +1,22 @@
 # benchmarks and research
 
-the project may link to historical articles, but they are not checkpoint evidence. a reproducible benchmark needs a rights-cleared corpus, frozen tasks, exact model and editor settings, a published rubric, separate evaluation dimensions, failure cases, and limitations.
+historical articles sit beside a frozen Hyv 3.2.0 baseline at `4e6269121d551c008a34db73077e1e4fea41b3f9`. they are dated product writing. a reproducible comparison still needs a rights-cleared corpus, frozen tasks, exact model and editor settings, a published rubric, separate evaluation dimensions, failure cases, and limitations.
 
-## stage 1 optional research protocol
+keep four reports distinct: unchanged 3.2.0, Stage 1, advanced edit, and rebuild. do not fold edit and rebuild into one preservation number.
 
-the checkoutable baseline is `4e6269121d551c008a34db73077e1e4fea41b3f9`. the hardcoded `STAGE1_COMMIT` is `550ea24f652291dca13757fdbd2f0fa0b5e3f621`; it is not retrievable from origin after the PR #27 squash merge. the merged head is `32d35eb35246696f0a56e7732d714ca6c22060f7`. no committed locked-human protocol digest exists.
+| arm | identity | what it is |
+|---|---|---|
+| unchanged Hyv 3.2.0 | `4e6269121d551c008a34db73077e1e4fea41b3f9` | frozen comparison baseline |
+| Stage 1 | `32d35eb35246696f0a56e7732d714ca6c22060f7` | founder-aware Stage 1 on main |
+| advanced edit | `1ffaabe2586adf11a2ed6db4dba8d1d88095f507` | judgments and range edits |
+| rebuild | `387de69eae9ec176f32bfb0f3a7b769a4e0b6686` | authorized rebuild |
 
-run both packets outside the repository:
+maintainer packets emit outside the repository:
 
 ```bash
 npm run stage1:dry-run -- --out /absolute/path/outside-the-repository/stage1-dry-run
 npm run stage1:human-packet -- --out /absolute/path/outside-the-repository/stage1-human-packet
-```
-
-the human-study kit does not pass MAR-362. the automated harness is not human evidence. `hyv_score` and ratings produced by a model or agent are not writer evidence. kit `--out` is emit-only, not approved encrypted custody. do not capture the Stage 1 arm until `STAGE1_COMMIT` is checkoutable, and do not label merged-HEAD bytes as that commit. shape-checked receipts remain unverified.
-
-while `human_writer_evidence_deferred` is forced, the report decision is `BLOCKED` and `PASS` is unreachable. the only dispositions are `STOP` and `REPEAT_PROTOCOL`. `PROCEED_TO_MAR_363` is rejected with `human_evidence_deferred`. writer-study kits stay optional research. product npm publish uses the version bump and CI. keep writer-checkpoint claims off the publish.
-
-## stage 2 and rebuild
-
-keep four reports: unchanged 3.2.0, Stage 1, advanced edit, and rebuild. do not merge edit and rebuild preservation. emit the Stage 2 kit outside the repository:
-
-```bash
 npm run stage2:human-packet -- --out /absolute/path/outside-the-repository/stage2-human-packet
 ```
 
-the kit stays BLOCKED and cannot promote MAR-364. keep `PROCEED_TO_MAR_365` and writer-checkpoint claims off the record. product npm publish uses the version bump and CI.
-
-remaining human inputs are a rights-approved non-synthetic corpus, encrypted custody, a reviewer roster, trust keys, provider captures, blind ratings with external receipts, a mapping-custody attestation, and a checkpoint disposition.
+see `benchmarks/README.md` for the locked-run commands.

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -14,6 +14,7 @@ node dist/cli.js reduce-judgment envelope.json envelope.json [envelope.json...]
 node dist/cli.js prepare-rebuild draft.md profile.json reduction.json copy-spec.json task.json [writing-brief.json] (--capability-stdin|--capability-file path)
 node dist/cli.js apply-rebuild task.json response.json profile.json (--capability-stdin|--capability-file path)
 node dist/cli.js verify original.md candidate.md profile.json [writing-brief.json]
+node dist/cli.js verify-spec original.md candidate.md profile.json copy-spec.json
 node dist/cli.js lifecycle prepare-semantic deterministic.json binding.json receipt.json normal violations.json lifecycle.json
 node dist/cli.js lifecycle submit-verdict lifecycle.json task.json evaluator-id verdict.json
 node dist/cli.js lifecycle inspect lifecycle.json
@@ -24,7 +25,7 @@ node dist/cli.js learning record-approved ready.json approved.json original.md c
 node dist/cli.js patterns
 ```
 
-`profile` needs two or more samples and writes only the profile path you name. `analyze` returns independent VoiceDNA and AI Editor reports plus a separate non-scoring Unicode hygiene report. An optional WritingBrief adds local audience, intent, and format context without changing the VoiceDNA profile. `hygiene` needs no profile; inspection is read-only, while `--fix` writes a new cleaned path, reports every changed offset, and refuses to overwrite either input or an existing output. Bidirectional controls, tag characters, and zero-width joiners/non-joiners are reported but preserved. `batch-analyze` returns advisory exact duplicate opening and closing findings across a local set. `rewrite-prompt` prints markdown and never calls a model. `verify` is read-only; learning changes require an explicit learning command or separately approved lifecycle transition.
+`profile` needs two or more samples and writes only the profile path you name. `analyze` returns independent VoiceDNA and AI Editor reports plus a separate non-scoring Unicode hygiene report. An optional WritingBrief adds local audience, intent, and format context without changing the VoiceDNA profile. `hygiene` needs no profile; inspection is read-only, while `--fix` writes a new cleaned path, reports every changed offset, and refuses to overwrite either input or an existing output. Bidirectional controls, tag characters, and zero-width joiners/non-joiners are reported but preserved. `batch-analyze` returns advisory exact duplicate opening and closing findings across a local set. `rewrite-prompt` prints markdown and never calls a model. `verify` is read-only; learning changes require an explicit learning command or separately approved lifecycle transition. `verify-spec` adds the CopySpec claim gate.
 
 `learning show` composes active preferences. `learning inspect` returns bounded text-free event metadata. `learning add` remains the compatibility form of `learning record`; the latter returns the full mutation receipt and accepts `--mutation-id`, `--authority`, `--provenance`, `--weight`, and `--compatibility`. `learning ratify` and `learning supersede` require Profile v3 plus an event ID. `learning migrate <source-v2.json> <target-v3.json>` explicitly moves compatible legacy history into the stable v3 identity. `learning clear` removes that identity's local state. Exact mutation replay is idempotent; conflicting mutation-ID reuse fails closed.
 

--- a/docs/wiki/Core-Concepts.md
+++ b/docs/wiki/Core-Concepts.md
@@ -4,6 +4,10 @@ VoiceDNA asks whether a draft resembles observable mechanics in local samples. A
 
 A WritingBrief is optional local context for audience, intent, format, vocabulary, and explicit prohibited terms. It can also carry an evidence state and a four-part argument map: observation, mechanism, consequence, and reader value. These remain advisory editorial context and do not change VoiceDNA measurements, profile storage, or the default analysis result. Batch analysis separately catches exact repeated opening and closing sentences across a local set of drafts.
 
-the combined `passed` value is logical AND. verification adds two safeguards: no new red finding and at least 70 lexical preservation. this makes the decision visible instead of hiding it behind a single quality score.
+Profile v3 applies catalog policy after matching. a rule can block, advise, require judgment, or stay disabled without changing its catalog ID.
+
+pre-edit judgments reduce findings to SHIP, bounded EDIT, or REBUILD. SHIP returns original bytes. EDIT unlocks only eligible sentences or contiguous ranges. REBUILD is a separate whole-document contract: it needs a matching recommendation, a CopySpec, and a signed rebuild-authorization capability. edit and rebuild responses are mutually incompatible.
+
+the combined `passed` value is logical AND. verification adds two safeguards: no new red finding and at least 70 lexical preservation. authorized rebuild may keep a lower lexical-survival floor while claim, polarity, hygiene, and semantic gates stay in force. this makes the decision visible instead of hiding it behind a single quality score.
 
 the tool is a gate around an editor or a model you choose. generation happens outside the package.

--- a/docs/wiki/FAQ-and-Troubleshooting.md
+++ b/docs/wiki/FAQ-and-Troubleshooting.md
@@ -6,7 +6,11 @@ a red finding blocks release even if the numeric score is high. inspect the engi
 
 ## why does verification return 2?
 
-the candidate failed VoiceDNA, AI Editor, the new-red-regression check, or the 70 lexical-preservation guardrail. `2` means the candidate failed. `1` means the command had a usage or runtime error.
+the candidate failed VoiceDNA, AI Editor, the new-red-regression check, or the 70 lexical-preservation guardrail. `apply-rewrite` and `apply-rebuild` use the same exit code when a candidate is not accepted. `2` means the candidate failed. `1` means the command had a usage or runtime error.
+
+## when does a draft SHIP, EDIT, or REBUILD?
+
+a pre-edit judgment reduces findings to one recommendation. SHIP returns the original bytes. EDIT unlocks eligible sentences or contiguous ranges. REBUILD needs a matching recommendation, a CopySpec, and a signed rebuild-authorization capability. a caller cannot self-select rebuild.
 
 ## can this prove authorship or factual accuracy?
 

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,14 +1,25 @@
 # getting started
 
+the public CLI is [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) 3.3.0.
+
+```bash
+npx @holdyourvoice/hyv patterns
+npm install --global @holdyourvoice/hyv
+hyv patterns
+```
+
+to work from source:
+
 1. clone the repository and run `npm install`.
 2. run `npm test` and `npm run build`.
 3. create a profile from at least two local samples:
 
 ```bash
-node dist/cli.js profile profile.json sample-a.md sample-b.md --avoid=overused-phrase
+hyv profile profile.json sample-a.md sample-b.md --avoid=overused-phrase
 ```
 
-4. inspect a draft with `node dist/cli.js analyze draft.md profile.json`.
-5. create a brief with `node dist/cli.js rewrite-prompt draft.md profile.json > rewrite-brief.md`, apply only the replacements you accept, then run `verify`.
+4. inspect a draft with `hyv analyze draft.md profile.json`.
+5. create a brief with `hyv rewrite-prompt draft.md profile.json > rewrite-brief.md`, apply only the replacements you accept, then run `verify`.
+6. for the founder-aware path, reduce a pre-edit judgment to SHIP, EDIT, or REBUILD, then use `prepare-rewrite` / `apply-rewrite` or `prepare-rebuild` / `apply-rebuild` as the recommendation requires.
 
-the package is private until a deliberate npm publication. use the local CLI path above.
+use `npx @holdyourvoice/hyv` in place of `hyv` when the CLI is not installed globally. from a built checkout, `node dist/cli.js` is the same binary.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -2,6 +2,6 @@
 
 a draft can sound less generic and still lose the writer. it can also copy a writer's cadence while making empty claims. hold your voice keeps those checks separate.
 
-the local CLI builds a portable VoiceDNA profile from your samples, runs VoiceDNA and AI Editor as independent engines, creates a five-tier rewrite brief, and verifies a candidate. verification is read-only; explicit or separately approved operations build [local voice memory](Local-Voice-Memory) from text-free resolved finding IDs. model calls, uploads, accounts, and telemetry stay outside the package.
+the public package is [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) 3.3.0. it is the founder-aware rewrite: Profile v3 policy, pre-edit SHIP/EDIT/REBUILD judgments, contiguous range edits, authorized rebuild, and a signed semantic lifecycle. the local CLI builds a portable VoiceDNA profile from your samples, runs VoiceDNA and AI Editor as independent engines, creates a five-tier rewrite brief, and verifies a candidate. verification is read-only; explicit or separately approved operations build [local voice memory](Local-Voice-Memory) from text-free resolved finding IDs. model calls, uploads, accounts, and telemetry stay outside the package.
 
-start with [getting started](Getting-Started). read [core concepts](Core-Concepts) before adding a rule.
+start with [getting started](Getting-Started). read [core concepts](Core-Concepts) before adding a rule. the [cli reference](CLI-Reference) lists the structured rewrite commands.

--- a/docs/wiki/Local-Voice-Memory.md
+++ b/docs/wiki/Local-Voice-Memory.md
@@ -39,6 +39,6 @@ hyv learning clear profile.json
 
 ## boundaries
 
-memory is a priority hint, not a third score. it never changes VoiceDNA or AI Editor scoring, and it cannot make either engine pass. learned hints cannot override tier 0 preservation, tier 1 blockers, clean-sentence preservation, or tier 4 output. the candidate still needs both engine passes, zero new red regressions, and at least 70 lexical preservation.
+memory is a priority hint, not a third score. it never changes VoiceDNA or AI Editor scoring, and it cannot make either engine pass. learned hints cannot override tier 0 preservation, tier 1 blockers, clean-sentence preservation, or tier 4 output. the candidate still needs both engine passes, zero new red regressions, and at least 70 lexical preservation. Profile v3 keys history by stable local identity, so compatible events survive a profile revision. `ratify`, `supersede`, and `migrate` manage that history without storing draft text.
 
 the Claude Desktop extension follows the same rule. its `hyv_verify` tool is read-only. approved learning writes only a recoverable, text-free event and never writes the supplied text.

--- a/docs/wiki/Tiered-Rewrite-Workflow.md
+++ b/docs/wiki/Tiered-Rewrite-Workflow.md
@@ -10,3 +10,5 @@ the brief has five fixed tiers. optional editorial context sits between AI Edito
 6. output contract: return only replacement sentences keyed by sentence number.
 
 the brief is a prompt generator. it never rewrites text or makes a provider call.
+
+rebuild is a separate contract. after an upstream REBUILD recommendation, a CopySpec, and a signed rebuild-authorization capability, the host returns a whole-document candidate. that path does not use sentence-number replacements. claim, polarity, hygiene, and semantic gates stay in force.

--- a/docs/wiki/Verification-and-Quality-Gates.md
+++ b/docs/wiki/Verification-and-Quality-Gates.md
@@ -4,6 +4,10 @@
 
 a candidate passes only when VoiceDNA passes, AI Editor passes, no new red regression appears, and lexical preservation is at least 70. lexical preservation only measures retained longer words. a human must still check facts, intent, and sources.
 
-use exit code `2` for a failed candidate and exit code `1` for a usage or runtime failure.
+authorized rebuild keeps claim, polarity, hygiene, fingerprint, and semantic gates. low lexical survival is allowed only on that signed rebuild path.
+
+use exit code `2` for a failed candidate and exit code `1` for a usage or runtime failure. `apply-rewrite`, `apply-rebuild`, `lifecycle submit-verdict`, and `lifecycle finalize` follow the same exit codes.
 
 CopySpec checks are deterministic. A normal immutable claim must remain verbatim. When a claim includes `atoms`, each declared phrase must remain in the candidate, which permits independent facts to be split or reordered. Atoms are lexical-presence checks, so place the whole relationship in one atom when it is immutable. CopySpec preserves declared text; it does not establish whether a claim is true.
+
+pre-edit judgments bind SHIP, EDIT, or REBUILD to the draft, profile, and evidence scope. post-candidate judgments clear the same kinds after verification. SHIP returns original bytes without a model response.

--- a/docs/wiki/VoiceDNA.md
+++ b/docs/wiki/VoiceDNA.md
@@ -1,7 +1,32 @@
-# voicedna
+# VoiceDNA: 13 elements
 
-a profile uses at least two non-empty local samples and contains exactly 13 elements: sentence length, sentence variation, sentence structure, rhythm, paragraph length, opening moves, vocabulary, lexical density, point of view, punctuation, case style, question rate, and transitions. structural metrics accept Unicode writing; the current point-of-view and transition lists are English-specific evidence.
+VoiceDNA is a local profile of observable writing mechanics. Build it from at least two non-empty samples from one writer. It compares a draft with those samples; it does not identify an author or determine whether AI wrote a passage.
 
-every element is calculated and included in the JSON profile. the automated checks are intentionally narrower: sentence length, explicit avoid-list phrases, question rate, case style, and point of view. avoid-list matches are red. the other active checks are yellow review cues.
+Structural measurements accept Unicode writing. The current point-of-view and transition lists are English-specific evidence.
 
-the profile makes no identity, personality, or authorship claim. it is a portable record of selected writing mechanics.
+| Element | What it records | What drift means |
+| --- | --- | --- |
+| 1. Sentence length | Mean words per sentence | The draft is materially shorter or longer than the reference. |
+| 2. Sentence variation | Spread of sentence lengths | The draft is unusually even or erratic. |
+| 3. Sentence structure | Frequent three-word opening shapes | Sentences begin in unfamiliar patterns. |
+| 4. Rhythm | Length change between neighbouring sentences | The beat has flattened or become needlessly choppy. |
+| 5. Paragraph length | Mean sentences per paragraph | Visual pacing has drifted. |
+| 6. Opening moves | Common first words | The piece enters unlike the reference samples. |
+| 7. Vocabulary | Frequent non-stop words | Familiar concrete language is missing or displaced. |
+| 8. Lexical density | Share of non-stop words | The draft is unusually generic or compressed. |
+| 9. Point of view | First-, second-, third-person, or mixed | Normal narrative distance changed. |
+| 10. Punctuation | Counts of selected marks | Emphasis or pauses differ from the reference. |
+| 11. Case style | Lowercase, standard, or mixed | Capitalization no longer matches the writer’s convention. |
+| 12. Question rate | Share of sentences ending in questions | The draft asks materially more or fewer questions. |
+| 13. Transitions | Frequent recognised connectors | The movement between ideas differs from the reference. |
+
+## Current automated policy
+
+- Explicit avoid-list phrases are red release blockers.
+- Sentence-length drift is a yellow review cue outside `max(8 words, 2.2 × profile variation)` from the reference mean.
+- Question-rate, case-style, and non-mixed point-of-view drift are yellow review cues.
+- The remaining elements stay visible in the JSON profile and rewrite brief as evidence for an editor.
+
+Yellow findings ask for editorial judgment. They do not prove a line is wrong. Any new automatic rule needs a written policy, positive tests, and counterexamples.
+
+Profile v3 adds a stable local identity and per-rule policy. Catalog matches can block, advise, require judgment, or stay disabled without changing rule IDs. Revision compatibility decides which local learning events stay active.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -20,6 +20,8 @@
 
 [pattern catalog](Pattern-Catalog)
 
+[AI writing patterns](AI-Writing-Patterns)
+
 [architecture](Architecture)
 
 [privacy and data rights](Privacy-and-Data-Rights)


### PR DESCRIPTION
## Summary

README and wiki now describe 3.3.0 as the public founder-aware rewrite: Profile v3 policy, SHIP/EDIT/REBUILD judgments, contiguous range edits, authorized rebuild, and the signed semantic lifecycle.

The live GitHub wiki is already updated. This PR keeps the tracked `docs/wiki` sources and README in sync.

## Test plan

- [x] README commands match the 3.3.0 CLI
- [x] Wiki Home and Getting Started point at the public npm package
- [ ] GitHub wiki pages render after the push

Made with [Cursor](https://cursor.com)