### PR TITLE
ci: mirror pushes to Stitchflow Builders

### DIFF
--- a/.github/workflows/mirror-to-stitchflow.yml
+++ b/.github/workflows/mirror-to-stitchflow.yml
@@ -1,0 +1,32 @@
+name: Mirror to Stitchflow Builders
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "**"
+
+permissions:
+  contents: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push source branches and tags to the private mirror
+        env:
+          MIRROR_DEPLOY_KEY: ${{ secrets.MIRROR_DEPLOY_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$MIRROR_DEPLOY_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
+          git remote set-head origin -d
+          git remote add mirror git@github.com:stitchflow-builders/holdyourvoice.git
+          git push --prune mirror '+refs/remotes/origin/*:refs/heads/*' '+refs/tags/*:refs/tags/*'


### PR DESCRIPTION
Adds a push-only workflow that copies source branches and tags to the private stitchflow-builders/holdyourvoice mirror. The destination is never fetched or merged back. It authenticates with a destination-scoped deploy key stored as an Actions secret.