### PR TITLE
chore(release): publish 3.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "hold-your-voice",
       "source": "./claude-plugin",
       "description": "Keep a writer's voice while using Claude.",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "author": {
         "name": "Shashank SN"
       }

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Those programs keep separate findings, scores, and pass states. A strong result 
 
 Everything in the CLI runs from local files: accounts, API calls, telemetry, payment collection, and runtime network requests stay out of the core path. The optional Claude extension adds a local stdio MCP adapter around that same engine; it is not a hosted service.
 
-> **Status:** [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) **3.3.1** is the public founder-aware rewrite. It runs locally and makes no runtime network requests. The package includes Profile v3 policy, pre-edit SHIP/EDIT/REBUILD judgments, contiguous range edits, authorized rebuild, and a signed semantic lifecycle.
+> **Status:** [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) **3.3.2** is the public founder-aware rewrite. It runs locally and makes no runtime network requests. The package includes Profile v3 policy, pre-edit SHIP/EDIT/REBUILD judgments, contiguous range edits, authorized rebuild, and a signed semantic lifecycle.
 
 ## Why it exists
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "hold-your-voice",
   "displayName": "Hold Your Voice",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "A local-first writing gate for VoiceDNA, AI-editor patterns, and Unicode hygiene.",
   "author": {
     "name": "Shashank SN",

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "hold-your-voice": {
       "command": "npm",
-      "args": ["exec", "--yes", "--package=@holdyourvoice/hyv@3.3.1", "--", "hyv", "mcp"]
+      "args": ["exec", "--yes", "--package=@holdyourvoice/hyv@3.3.2", "--", "hyv", "mcp"]
     }
   }
 }

--- a/docs/CLAUDE-CODE.md
+++ b/docs/CLAUDE-CODE.md
@@ -11,7 +11,7 @@ In Claude Code, run:
 /plugin install hold-your-voice@hold-your-voice
 ```
 
-Node.js 20 or newer and npm must be installed. Claude Code uses `npm exec --package=@holdyourvoice/hyv@3.3.1 -- hyv mcp` to download the pinned public package and start a local stdio process.
+Node.js 20 or newer and npm must be installed. Claude Code uses `npm exec --package=@holdyourvoice/hyv@3.3.2 -- hyv mcp` to download the pinned public package and start a local stdio process.
 
 ## What it exposes
 

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,6 +1,6 @@
 # getting started
 
-the public CLI is [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) 3.3.1.
+the public CLI is [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) 3.3.2.
 
 ```bash
 npx @holdyourvoice/hyv patterns

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -2,7 +2,7 @@
 
 a draft can sound less generic and still lose the writer. it can also copy a writer's cadence while making empty claims. hold your voice keeps those checks separate.
 
-the public package is [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) 3.3.1. it is the founder-aware rewrite: Profile v3 policy, pre-edit SHIP/EDIT/REBUILD judgments, contiguous range edits, authorized rebuild, and a signed semantic lifecycle. the local CLI builds a portable VoiceDNA profile from your samples, runs VoiceDNA and AI Editor as independent engines, creates a five-tier rewrite brief, and verifies a candidate. verification is read-only; explicit or separately approved operations build [local voice memory](Local-Voice-Memory) from text-free resolved finding IDs. model calls, uploads, accounts, and telemetry stay outside the package.
+the public package is [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) 3.3.2. it is the founder-aware rewrite: Profile v3 policy, pre-edit SHIP/EDIT/REBUILD judgments, contiguous range edits, authorized rebuild, and a signed semantic lifecycle. the local CLI builds a portable VoiceDNA profile from your samples, runs VoiceDNA and AI Editor as independent engines, creates a five-tier rewrite brief, and verifies a candidate. verification is read-only; explicit or separately approved operations build [local voice memory](Local-Voice-Memory) from text-free resolved finding IDs. model calls, uploads, accounts, and telemetry stay outside the package.
 
 start with [getting started](Getting-Started). read [core concepts](Core-Concepts) before adding a rule. the [cli reference](CLI-Reference) lists the structured rewrite commands.
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "hold-your-voice",
   "display_name": "Hold Your Voice",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Keep your writing voice when you use Claude.",
   "long_description": "A fully local writing gate for Claude Desktop. Run a profile-free final-output check on text from any source, build a VoiceDNA profile from your own samples, inspect a draft with separate VoiceDNA and AI Editor checks plus non-scoring Unicode hygiene, create a constrained editing brief, and verify a revised candidate. Clean final output passes through unchanged; only a leading byte-order mark is removed automatically, while unresolved hidden Unicode is withheld for review. Verification is read-only. Explicit or separately approved learning stores no drafts or samples and makes no network requests.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holdyourvoice/hyv",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holdyourvoice/hyv",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holdyourvoice/hyv",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "A local-first dual-engine writing gate that protects voice and catches generic AI patterns.",
   "type": "module",
   "bin": { "hyv": "dist/cli.js" },

--- a/src/rebuild-task.test.ts
+++ b/src/rebuild-task.test.ts
@@ -191,7 +191,7 @@ test('CLI and MCP rebuild helpers share fingerprints', () => {
     version: '1', audience: 'operators', intent: 'explain', format: 'outreach',
   });
   assert.match(briefTask.prompt, /# WritingBrief/);
-  assert.equal(HYV_VERSION, '3.3.1');
+  assert.equal(HYV_VERSION, '3.3.2');
 });
 
 test('apply rejects forged tasks, missing capability, and substituted profiles', () => {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const HYV_VERSION = '3.3.1';
+export const HYV_VERSION = '3.3.2';


### PR DESCRIPTION
Release 3.3.2 publishes the fact-linter work already merged into main and keeps every public package surface pinned to the same version.

Validation: `npm test` (288 passing), `npm run check:release`, and `npm run pack:claude` all pass locally.
