### PR TITLE
fix(release): verify downloadable npm package

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "hold-your-voice",
       "source": "./claude-plugin",
       "description": "Keep a writer's voice while using Claude.",
-      "version": "3.3.3",
+      "version": "3.3.4",
       "author": {
         "name": "Shashank SN"
       }

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -49,12 +49,17 @@ jobs:
       - name: Verify registry package
         run: |
           version=$(node -p "require('./package.json').version")
+          package_dir=$(mktemp -d)
+          trap 'rm -rf "$package_dir"' EXIT
           for attempt in 1 2 3 4 5 6; do
             if npm view "@holdyourvoice/hyv@${version}" version 2>/dev/null | grep -qxF "$version" \
-              && test "$(npm view "@holdyourvoice/hyv@${version}" license)" = "MIT"; then
+              && test "$(npm view "@holdyourvoice/hyv@${version}" license)" = "MIT" \
+              && npm pack "@holdyourvoice/hyv@${version}" --pack-destination "$package_dir" >/dev/null 2>&1 \
+              && test -n "$(find "$package_dir" -maxdepth 1 -name '*.tgz' -print -quit)"; then
               exit 0
             fi
+            rm -f "$package_dir"/*.tgz
             sleep 5
           done
-          echo "npm did not expose @holdyourvoice/hyv@${version} with an MIT license"
+          echo "npm did not expose a downloadable @holdyourvoice/hyv@${version} package with an MIT license"
           exit 1

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Those programs keep separate findings, scores, and pass states. A strong result 
 
 Everything in the CLI runs from local files: accounts, API calls, telemetry, payment collection, and runtime network requests stay out of the core path. The optional Claude extension adds a local stdio MCP adapter around that same engine; it is not a hosted service.
 
-> **Status:** [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) **3.3.3** is the public founder-aware rewrite. It runs locally and makes no runtime network requests. The package includes Profile v3 policy, pre-edit SHIP/EDIT/REBUILD judgments, contiguous range edits, authorized rebuild, and a signed semantic lifecycle.
+> **Status:** [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) **3.3.4** is the public founder-aware rewrite. It runs locally and makes no runtime network requests. The package includes Profile v3 policy, pre-edit SHIP/EDIT/REBUILD judgments, contiguous range edits, authorized rebuild, and a signed semantic lifecycle.
 
 ## Why it exists
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "hold-your-voice",
   "displayName": "Hold Your Voice",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "A local-first writing gate for VoiceDNA, AI-editor patterns, and Unicode hygiene.",
   "author": {
     "name": "Shashank SN",

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "hold-your-voice": {
       "command": "npm",
-      "args": ["exec", "--yes", "--package=@holdyourvoice/hyv@3.3.3", "--", "hyv", "mcp"]
+      "args": ["exec", "--yes", "--package=@holdyourvoice/hyv@3.3.4", "--", "hyv", "mcp"]
     }
   }
 }

--- a/docs/CLAUDE-CODE.md
+++ b/docs/CLAUDE-CODE.md
@@ -11,7 +11,7 @@ In Claude Code, run:
 /plugin install hold-your-voice@hold-your-voice
 ```
 
-Node.js 20 or newer and npm must be installed. Claude Code uses `npm exec --package=@holdyourvoice/hyv@3.3.3 -- hyv mcp` to download the pinned public package and start a local stdio process.
+Node.js 20 or newer and npm must be installed. Claude Code uses `npm exec --package=@holdyourvoice/hyv@3.3.4 -- hyv mcp` to download the pinned public package and start a local stdio process.
 
 ## What it exposes
 

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,6 +1,6 @@
 # getting started
 
-the public CLI is [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) 3.3.3.
+the public CLI is [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) 3.3.4.
 
 ```bash
 npx @holdyourvoice/hyv patterns

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -2,7 +2,7 @@
 
 a draft can sound less generic and still lose the writer. it can also copy a writer's cadence while making empty claims. hold your voice keeps those checks separate.
 
-the public package is [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) 3.3.3. it is the founder-aware rewrite: Profile v3 policy, pre-edit SHIP/EDIT/REBUILD judgments, contiguous range edits, authorized rebuild, and a signed semantic lifecycle. the local CLI builds a portable VoiceDNA profile from your samples, runs VoiceDNA and AI Editor as independent engines, creates a five-tier rewrite brief, and verifies a candidate. verification is read-only; explicit or separately approved operations build [local voice memory](Local-Voice-Memory) from text-free resolved finding IDs. model calls, uploads, accounts, and telemetry stay outside the package.
+the public package is [`@holdyourvoice/hyv`](https://www.npmjs.com/package/@holdyourvoice/hyv) 3.3.4. it is the founder-aware rewrite: Profile v3 policy, pre-edit SHIP/EDIT/REBUILD judgments, contiguous range edits, authorized rebuild, and a signed semantic lifecycle. the local CLI builds a portable VoiceDNA profile from your samples, runs VoiceDNA and AI Editor as independent engines, creates a five-tier rewrite brief, and verifies a candidate. verification is read-only; explicit or separately approved operations build [local voice memory](Local-Voice-Memory) from text-free resolved finding IDs. model calls, uploads, accounts, and telemetry stay outside the package.
 
 start with [getting started](Getting-Started). read [core concepts](Core-Concepts) before adding a rule. the [cli reference](CLI-Reference) lists the structured rewrite commands.
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "hold-your-voice",
   "display_name": "Hold Your Voice",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Keep your writing voice when you use Claude.",
   "long_description": "A fully local writing gate for Claude Desktop. Run a profile-free final-output check on text from any source, build a VoiceDNA profile from your own samples, inspect a draft with separate VoiceDNA and AI Editor checks plus non-scoring Unicode hygiene, create a constrained editing brief, and verify a revised candidate. Clean final output passes through unchanged; only a leading byte-order mark is removed automatically, while unresolved hidden Unicode is withheld for review. Verification is read-only. Explicit or separately approved learning stores no drafts or samples and makes no network requests.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holdyourvoice/hyv",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holdyourvoice/hyv",
-      "version": "3.3.3",
+      "version": "3.3.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holdyourvoice/hyv",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "A local-first dual-engine writing gate that protects voice and catches generic AI patterns.",
   "type": "module",
   "bin": { "hyv": "dist/cli.js" },

--- a/src/rebuild-task.test.ts
+++ b/src/rebuild-task.test.ts
@@ -191,7 +191,7 @@ test('CLI and MCP rebuild helpers share fingerprints', () => {
     version: '1', audience: 'operators', intent: 'explain', format: 'outreach',
   });
   assert.match(briefTask.prompt, /# WritingBrief/);
-  assert.equal(HYV_VERSION, '3.3.3');
+  assert.equal(HYV_VERSION, '3.3.4');
 });
 
 test('apply rejects forged tasks, missing capability, and substituted profiles', () => {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const HYV_VERSION = '3.3.3';
+export const HYV_VERSION = '3.3.4';


### PR DESCRIPTION
## Why\n\nThe npm registry exposed 3.3.3 metadata but its tarball URL returned HTTP 404. The previous workflow only checked metadata, so it reported success without proving that users could install the package.\n\n## Change\n\n- release 3.3.4 with all public package surfaces aligned\n- make the publish workflow download the exact published tarball with npm pack before it passes\n\n## Verification\n\n- npm test: 299 passing\n- npm run check:release: passed\n- npm pack --dry-run: passed (3.3.4 tarball)\n- git diff --check: passed\n\nAfter merge, the publish workflow must pass its downloadable-package smoke check before the release is considered live.