### PR TITLE
fix(ci): prevent private mirror workflow recursion

### DIFF
--- a/.github/workflows/mirror-to-stitchflow.yml
+++ b/.github/workflows/mirror-to-stitchflow.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   mirror:
+    if: github.repository == 'shashank-sn/holdyourvoice'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/scripts/release-audit.mjs
+++ b/scripts/release-audit.mjs
@@ -64,6 +64,7 @@ const claudePluginManifest = JSON.parse(readFileSync('claude-plugin/.claude-plug
 const marketplaceManifest = JSON.parse(readFileSync('.claude-plugin/marketplace.json', 'utf8'));
 const claudeMcpManifest = JSON.parse(readFileSync('claude-plugin/.mcp.json', 'utf8'));
 const runtimeVersionSource = readFileSync('src/version.ts', 'utf8');
+const mirrorWorkflow = readFileSync('.github/workflows/mirror-to-stitchflow.yml', 'utf8');
 const mitLicense = readFileSync('LICENSE', 'utf8');
 const mitRequiredClauses = [
   'Permission is hereby granted, free of charge, to any person obtaining a copy',
@@ -73,6 +74,9 @@ const mitRequiredClauses = [
 
 const files = candidateFiles();
 const failures = [];
+if (!mirrorWorkflow.includes("if: github.repository == 'shashank-sn/holdyourvoice'")) {
+  failures.push('mirror workflow must run only in the public source repository');
+}
 for (const [name, command] of Object.entries(stage1Scripts)) {
   if (packageManifest.scripts?.[name] !== command) failures.push(`Stage 1 script contract has drifted: ${name}`);
 }

--- a/src/release-audit.test.ts
+++ b/src/release-audit.test.ts
@@ -38,6 +38,7 @@ function fixture(files: Record<string, string>) {
     ].join('\n'),
     'src/version.ts': "export const HYV_VERSION = '1.0.0';",
     'src/stage1-evaluation.ts': "const baseline = '4e6269121d551c008a34db73077e1e4fea41b3f9'; const stage1 = '550ea24f652291dca13757fdbd2f0fa0b5e3f621';",
+    '.github/workflows/mirror-to-stitchflow.yml': "jobs:\n  mirror:\n    if: github.repository == 'shashank-sn/holdyourvoice'\n",
     'skills/hyv-test/agent.json': '{}',
     'skills/hyv-test/SKILL.md': '# test',
     'skills/hyv-test/agents/openai.yaml': 'name: test',
@@ -58,6 +59,20 @@ test('accepts the complete public package contract', () => {
     const result = spawnSync(process.execPath, [audit], { cwd: directory, encoding: 'utf8' });
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /release audit passed/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('requires the mirror workflow to run only in the public source repository', () => {
+  const directory = fixture({
+    'README.md': '# public',
+    '.github/workflows/mirror-to-stitchflow.yml': 'jobs:\n  mirror:\n    runs-on: ubuntu-latest\n',
+  });
+  try {
+    const result = spawnSync(process.execPath, [audit], { cwd: directory, encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /mirror workflow must run only in the public source repository/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- restrict the mirror job to `shashank-sn/holdyourvoice`
- stop the copied workflow before runner allocation inside the private mirror
- make release audit fail if the source-only guard is removed
- add a regression fixture for the missing-guard case

## Root cause

The source sync succeeded, then the copied workflow ran again inside `stitchflow-builders/holdyourvoice`. Secrets do not mirror, so `MIRROR_DEPLOY_KEY` was empty and the destination run failed during SSH authentication.

## Verification

- Clean Verify PASS at `ec79719a858aed66f66ddd3417d35594ef2060ce`
- 324/324 tests passed
- release audit passed
- Claude MCPB packaging passed
- independent Clean Review: 0 blocking, 0 improvement findings
- source mirror run succeeded: https://github.com/shashank-sn/holdyourvoice/actions/runs/32697473627
- destination run at the same SHA skipped with zero steps: https://github.com/stitchflow-builders/holdyourvoice/actions/runs/32697484467

## Known boundaries

- historical destination failures remain in GitHub Actions history
- a future source repository rename must update the guard, release audit, and regression fixture together
