### PR TITLE
fix(ci): make mirror reconciliation self-healing

### DIFF
--- a/.github/workflows/mirror-to-stitchflow.yml
+++ b/.github/workflows/mirror-to-stitchflow.yml
@@ -6,6 +6,14 @@ on:
       - "**"
     tags:
       - "**"
+  delete:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * *"
+
+concurrency:
+  group: mirror-to-stitchflow
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -14,8 +22,9 @@ jobs:
   mirror:
     if: github.repository == 'shashank-sn/holdyourvoice'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -23,11 +32,14 @@ jobs:
         env:
           MIRROR_DEPLOY_KEY: ${{ secrets.MIRROR_DEPLOY_KEY }}
         run: |
+          if [ -z "${MIRROR_DEPLOY_KEY:-}" ]; then
+            echo "::error::MIRROR_DEPLOY_KEY is not configured in the source repository."
+            exit 1
+          fi
+
           install -m 700 -d ~/.ssh
           printf '%s\n' "$MIRROR_DEPLOY_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git fetch origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
-          git remote set-head origin -d
           git remote add mirror git@github.com:stitchflow-builders/holdyourvoice.git
-          git push --prune mirror '+refs/remotes/origin/*:refs/heads/*' '+refs/tags/*:refs/tags/*'
+          node scripts/mirror-refs.mjs

--- a/scripts/mirror-refs.mjs
+++ b/scripts/mirror-refs.mjs
@@ -1,0 +1,71 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const headsRefspec = '+refs/remotes/origin/*:refs/heads/*';
+const tagsRefspec = '+refs/tags/*:refs/tags/*';
+
+function output(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function run(cwd, args) {
+  execFileSync('git', args, { cwd, stdio: 'inherit' });
+}
+
+function refLines(text) {
+  return text.trim() ? text.trim().split('\n').sort() : [];
+}
+
+function sourceRefs(cwd) {
+  return refLines(output(cwd, ['for-each-ref', '--format=%(objectname)\t%(refname)', 'refs/remotes/origin', 'refs/tags']))
+    .map((line) => line.replace('\trefs/remotes/origin/', '\trefs/heads/'))
+    .sort();
+}
+
+function mirroredRefs(cwd) {
+  return refLines(output(cwd, ['ls-remote', '--refs', 'mirror', 'refs/heads/*', 'refs/tags/*']));
+}
+
+function parityError(source, mirror) {
+  const sourceSet = new Set(source);
+  const mirrorSet = new Set(mirror);
+  const missing = source.filter((ref) => !mirrorSet.has(ref));
+  const unexpected = mirror.filter((ref) => !sourceSet.has(ref));
+  return new Error([
+    'Source and mirror refs differ after push.',
+    ...missing.map((ref) => `missing: ${ref}`),
+    ...unexpected.map((ref) => `unexpected: ${ref}`),
+  ].join('\n'));
+}
+
+async function pushWithRetry(cwd, attempts, delayMs) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = spawnSync('git', ['push', '--prune', 'mirror', headsRefspec, tagsRefspec], { cwd, stdio: 'inherit' });
+    if (result.error) throw result.error;
+    if (result.status === 0) return;
+    if (attempt === attempts) throw new Error(`Mirror push failed after ${attempts} attempts.`);
+    await new Promise((done) => setTimeout(done, delayMs * attempt));
+  }
+}
+
+export async function reconcileMirror({ cwd = process.cwd(), attempts = 3, delayMs = 5_000 } = {}) {
+  run(cwd, ['fetch', '--prune', '--prune-tags', 'origin', '+refs/heads/*:refs/remotes/origin/*', tagsRefspec]);
+  run(cwd, ['update-ref', '--no-deref', '-d', 'refs/remotes/origin/HEAD']);
+  await pushWithRetry(cwd, attempts, delayMs);
+
+  const source = sourceRefs(cwd);
+  const mirror = mirroredRefs(cwd);
+  if (source.length !== mirror.length || source.some((ref, index) => ref !== mirror[index])) {
+    throw parityError(source, mirror);
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await reconcileMirror();
+  } catch (error) {
+    console.error(`::error::${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release-audit.mjs
+++ b/scripts/release-audit.mjs
@@ -65,6 +65,7 @@ const marketplaceManifest = JSON.parse(readFileSync('.claude-plugin/marketplace.
 const claudeMcpManifest = JSON.parse(readFileSync('claude-plugin/.mcp.json', 'utf8'));
 const runtimeVersionSource = readFileSync('src/version.ts', 'utf8');
 const mirrorWorkflow = readFileSync('.github/workflows/mirror-to-stitchflow.yml', 'utf8');
+const mirrorReconciler = readFileSync('scripts/mirror-refs.mjs', 'utf8');
 const mitLicense = readFileSync('LICENSE', 'utf8');
 const mitRequiredClauses = [
   'Permission is hereby granted, free of charge, to any person obtaining a copy',
@@ -74,8 +75,21 @@ const mitRequiredClauses = [
 
 const files = candidateFiles();
 const failures = [];
-if (!mirrorWorkflow.includes("if: github.repository == 'shashank-sn/holdyourvoice'")) {
-  failures.push('mirror workflow must run only in the public source repository');
+const mirrorRequirements = [
+  [mirrorWorkflow, /^  delete:\s*$/m, 'mirror workflow must reconcile deleted refs'],
+  [mirrorWorkflow, /^  workflow_dispatch:\s*$/m, 'mirror workflow must support manual recovery'],
+  [mirrorWorkflow, /^  schedule:\n    - cron: ["']17 3 \* \* \*["']$/m, 'mirror workflow must reconcile refs on a schedule'],
+  [mirrorWorkflow, /^concurrency:\n  group: mirror-to-stitchflow\n  cancel-in-progress: false$/m, 'mirror workflow must serialize full-ref updates and finish the active update'],
+  [mirrorWorkflow, /^  mirror:\n    if: github\.repository == 'shashank-sn\/holdyourvoice'\n    runs-on: ubuntu-latest\n    timeout-minutes: 10$/m, 'mirror workflow must run only in the public source repository with a bounded timeout'],
+  [mirrorWorkflow, /^      - uses: actions\/checkout@v7$/m, 'mirror workflow must use the current checkout action'],
+  [mirrorWorkflow, /^ {10}if \[ -z "\$\{MIRROR_DEPLOY_KEY:-\}" \]; then$/m, 'mirror workflow must validate the source deploy key'],
+  [mirrorWorkflow, /^ {10}node scripts\/mirror-refs\.mjs$/m, 'mirror workflow must run the tested ref reconciler'],
+  [mirrorReconciler, /\['update-ref', '--no-deref', '-d', 'refs\/remotes\/origin\/HEAD'\]/, 'mirror reconciler must exclude the remote HEAD pseudo-ref without deleting the default branch'],
+  [mirrorReconciler, /\['push', '--prune', 'mirror', headsRefspec, tagsRefspec\]/, 'mirror reconciler must prune destination refs'],
+  [mirrorReconciler, /\['ls-remote', '--refs', 'mirror', 'refs\/heads\/\*', 'refs\/tags\/\*'\]/, 'mirror reconciler must verify source and mirror ref parity'],
+];
+for (const [text, pattern, failure] of mirrorRequirements) {
+  if (!pattern.test(text)) failures.push(failure);
 }
 for (const [name, command] of Object.entries(stage1Scripts)) {
   if (packageManifest.scripts?.[name] !== command) failures.push(`Stage 1 script contract has drifted: ${name}`);

--- a/src/mirror-refs.test.ts
+++ b/src/mirror-refs.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const mirrorScript = new URL('../scripts/mirror-refs.mjs', import.meta.url).pathname;
+
+function git(cwd: string, ...args: string[]) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function refs(repository: string) {
+  const text = git(repository, 'for-each-ref', '--format=%(objectname)\t%(refname)', 'refs/heads', 'refs/tags');
+  return text ? text.split('\n').sort() : [];
+}
+
+test('reconciles branch and tag creates, rewrites, and deletions', () => {
+  const root = mkdtempSync(join(tmpdir(), 'hyv-mirror-refs-'));
+  const source = join(root, 'source.git');
+  const mirror = join(root, 'mirror.git');
+  const checkout = join(root, 'checkout');
+
+  try {
+    git(root, 'init', '--bare', '--quiet', source);
+    git(root, 'init', '--bare', '--quiet', mirror);
+    git(root, 'clone', '--quiet', source, checkout);
+    git(checkout, 'config', 'user.name', 'Mirror Test');
+    git(checkout, 'config', 'user.email', 'mirror-test@example.invalid');
+    git(checkout, 'switch', '--quiet', '-c', 'main');
+    writeFileSync(join(checkout, 'main.txt'), 'first\n');
+    git(checkout, 'add', 'main.txt');
+    git(checkout, 'commit', '--quiet', '-m', 'first');
+    git(checkout, 'switch', '--quiet', '-c', 'feature/test');
+    writeFileSync(join(checkout, 'feature.txt'), 'feature\n');
+    git(checkout, 'add', 'feature.txt');
+    git(checkout, 'commit', '--quiet', '-m', 'feature');
+    git(checkout, 'tag', 'v1.0.0');
+    git(checkout, 'push', '--quiet', '--all', 'origin');
+    git(checkout, 'push', '--quiet', '--tags', 'origin');
+    git(source, 'symbolic-ref', 'HEAD', 'refs/heads/main');
+    git(checkout, 'remote', 'set-head', 'origin', '-a');
+    git(checkout, 'remote', 'add', 'mirror', mirror);
+
+    execFileSync(process.execPath, [mirrorScript], { cwd: checkout, stdio: 'pipe' });
+    assert.deepEqual(refs(mirror), refs(source));
+    assert.equal(refs(mirror).some((ref) => ref.endsWith('refs/heads/HEAD')), false);
+
+    git(checkout, 'switch', '--quiet', 'main');
+    writeFileSync(join(checkout, 'main.txt'), 'rewritten\n');
+    git(checkout, 'add', 'main.txt');
+    git(checkout, 'commit', '--quiet', '--amend', '-m', 'rewritten main');
+    git(checkout, 'branch', '-D', 'feature/test');
+    git(checkout, 'tag', '-d', 'v1.0.0');
+    git(checkout, 'tag', 'v2.0.0');
+    git(checkout, 'push', '--quiet', '--force', 'origin', 'main');
+    git(checkout, 'push', '--quiet', 'origin', '--delete', 'feature/test');
+    git(checkout, 'push', '--quiet', 'origin', ':refs/tags/v1.0.0');
+    git(checkout, 'push', '--quiet', 'origin', 'v2.0.0');
+
+    execFileSync(process.execPath, [mirrorScript], { cwd: checkout, stdio: 'pipe' });
+    assert.deepEqual(refs(mirror), refs(source));
+    assert.equal(refs(mirror).some((ref) => ref.endsWith('refs/heads/feature/test')), false);
+    assert.equal(refs(mirror).some((ref) => ref.endsWith('refs/tags/v1.0.0')), false);
+    assert.equal(refs(mirror).some((ref) => ref.endsWith('refs/tags/v2.0.0')), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/release-audit.test.ts
+++ b/src/release-audit.test.ts
@@ -6,6 +6,37 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import test from 'node:test';
 
 const audit = new URL('../scripts/release-audit.mjs', import.meta.url).pathname;
+const mirrorWorkflow = `on:
+  push:
+  delete:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * *'
+
+concurrency:
+  group: mirror-to-stitchflow
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    if: github.repository == 'shashank-sn/holdyourvoice'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - run: |
+          if [ -z "\${MIRROR_DEPLOY_KEY:-}" ]; then
+            exit 1
+          fi
+          node scripts/mirror-refs.mjs
+`;
+const mirrorReconciler = `
+const headsRefspec = '+refs/remotes/origin/*:refs/heads/*';
+const tagsRefspec = '+refs/tags/*:refs/tags/*';
+execFileSync('git', ['update-ref', '--no-deref', '-d', 'refs/remotes/origin/HEAD']);
+spawnSync('git', ['push', '--prune', 'mirror', headsRefspec, tagsRefspec]);
+execFileSync('git', ['ls-remote', '--refs', 'mirror', 'refs/heads/*', 'refs/tags/*']);
+`;
 const stage1Files = [
   'scripts/evaluate-rewrite-benchmark.mjs',
   'scripts/run-stage1-dry-run.mjs',
@@ -38,7 +69,8 @@ function fixture(files: Record<string, string>) {
     ].join('\n'),
     'src/version.ts': "export const HYV_VERSION = '1.0.0';",
     'src/stage1-evaluation.ts': "const baseline = '4e6269121d551c008a34db73077e1e4fea41b3f9'; const stage1 = '550ea24f652291dca13757fdbd2f0fa0b5e3f621';",
-    '.github/workflows/mirror-to-stitchflow.yml': "jobs:\n  mirror:\n    if: github.repository == 'shashank-sn/holdyourvoice'\n",
+    '.github/workflows/mirror-to-stitchflow.yml': mirrorWorkflow,
+    'scripts/mirror-refs.mjs': mirrorReconciler,
     'skills/hyv-test/agent.json': '{}',
     'skills/hyv-test/SKILL.md': '# test',
     'skills/hyv-test/agents/openai.yaml': 'name: test',
@@ -67,16 +99,62 @@ test('accepts the complete public package contract', () => {
 test('requires the mirror workflow to run only in the public source repository', () => {
   const directory = fixture({
     'README.md': '# public',
-    '.github/workflows/mirror-to-stitchflow.yml': 'jobs:\n  mirror:\n    runs-on: ubuntu-latest\n',
+    '.github/workflows/mirror-to-stitchflow.yml': mirrorWorkflow.replace("    if: github.repository == 'shashank-sn/holdyourvoice'\n", ''),
   });
   try {
     const result = spawnSync(process.execPath, [audit], { cwd: directory, encoding: 'utf8' });
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /mirror workflow must run only in the public source repository/);
+    assert.match(result.stderr, /mirror workflow must run only in the public source repository with a bounded timeout/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
 });
+
+for (const requirement of [
+  { name: 'deleted refs', fragment: '  delete:\n', error: /mirror workflow must reconcile deleted refs/ },
+  { name: 'manual recovery', fragment: '  workflow_dispatch:\n', error: /mirror workflow must support manual recovery/ },
+  { name: 'scheduled reconciliation', fragment: "  schedule:\n    - cron: '17 3 \* \* \*'\n", error: /mirror workflow must reconcile refs on a schedule/ },
+  { name: 'serialized updates', fragment: '  group: mirror-to-stitchflow\n', error: /mirror workflow must serialize full-ref updates and finish the active update/ },
+  { name: 'non-cancelled active updates', fragment: '  cancel-in-progress: false\n', error: /mirror workflow must serialize full-ref updates and finish the active update/ },
+  { name: 'bounded execution', fragment: '    timeout-minutes: 10\n', error: /mirror workflow must run only in the public source repository with a bounded timeout/ },
+  { name: 'current checkout action', fragment: '      - uses: actions/checkout@v7\n', error: /mirror workflow must use the current checkout action/ },
+  { name: 'deploy-key validation', fragment: '          if [ -z "${MIRROR_DEPLOY_KEY:-}" ]; then\n', error: /mirror workflow must validate the source deploy key/ },
+  { name: 'tested reconciliation', fragment: '          node scripts/mirror-refs.mjs\n', error: /mirror workflow must run the tested ref reconciler/ },
+]) {
+  test(`requires mirror ${requirement.name}`, () => {
+    const directory = fixture({
+      'README.md': '# public',
+      '.github/workflows/mirror-to-stitchflow.yml': mirrorWorkflow.replace(requirement.fragment, ''),
+    });
+    try {
+      const result = spawnSync(process.execPath, [audit], { cwd: directory, encoding: 'utf8' });
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, requirement.error);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+}
+
+for (const requirement of [
+  { name: 'safe remote HEAD exclusion', fragment: "execFileSync('git', ['update-ref', '--no-deref', '-d', 'refs/remotes/origin/HEAD']);\n", error: /mirror reconciler must exclude the remote HEAD pseudo-ref without deleting the default branch/ },
+  { name: 'destination pruning', fragment: "spawnSync('git', ['push', '--prune', 'mirror', headsRefspec, tagsRefspec]);\n", error: /mirror reconciler must prune destination refs/ },
+  { name: 'post-push ref verification', fragment: "execFileSync('git', ['ls-remote', '--refs', 'mirror', 'refs/heads/*', 'refs/tags/*']);\n", error: /mirror reconciler must verify source and mirror ref parity/ },
+]) {
+  test(`requires mirror reconciler ${requirement.name}`, () => {
+    const directory = fixture({
+      'README.md': '# public',
+      'scripts/mirror-refs.mjs': mirrorReconciler.replace(requirement.fragment, ''),
+    });
+    try {
+      const result = spawnSync(process.execPath, [audit], { cwd: directory, encoding: 'utf8' });
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, requirement.error);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+}
 
 test('requires exact Stage 1 scripts even when the checkpoint files remain', () => {
   const directory = fixture({


### PR DESCRIPTION
## summary

- reconcile the full source branch and tag set on push, delete, manual dispatch, and a daily recovery run
- serialize mirror jobs, retry transient push failures, prune deleted refs, and fail when post-push parity is not exact
- lock the workflow contract with a bare-Git integration test and release-audit checks

## verification

- Clean Verify: PASS on `518f389085dce11e8d2cbb00e96d24f0adde4a64`, 337/337 tests
- Clean Review: PASS, zero findings
- `npm run check:release`: PASS
- `git diff --check`: PASS
- source push run: https://github.com/shashank-sn/holdyourvoice/actions/runs/32700321283
- destination copy: https://github.com/stitchflow-builders/holdyourvoice/actions/runs/32700334313, skipped with the same SHA

## rollout

after merge, backport the safe workflow to the nine merged legacy branch tips. then exercise manual recovery and branch deletion, and compare every source and mirror ref.

one historical boundary remains outside this repository: a new ref deliberately created from an old unguarded commit can execute that commit's copied workflow while GitHub Actions remains enabled in the private mirror. disabling Actions there requires Stitchflow repository-admin access.
