### PR TITLE
docs: add verified product flow

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,68 @@ It runs two independent checks:
 
 The package also checks hidden Unicode, source-backed facts, document logic, and protected claims. All checks run locally, without model calls, automatic draft changes, or runtime network requests.
 
+## how it works
+
+```mermaid
+flowchart TD
+    samples["Writing samples"] --> profile["Build a local VoiceDNA profile"]
+    draft["Draft"] --> analyze["Analyze locally"]
+    profile --> analyze
+    brief["Optional WritingBrief"] --> analyze
+
+    analyze --> voice["VoiceDNA fit"]
+    analyze --> patterns["AI Editor rules"]
+    analyze --> editorial["Optional editorial report"]
+    analyze --> hygiene["Separate, non-scoring hidden Unicode report"]
+
+    voice --> route{"Local result"}
+    patterns --> route
+    editorial --> route
+
+    route -->|No blocking change| final["Run final-check"]
+    route -->|Blocking sentences| edit["Prepare a fingerprint-bound edit task"]
+    route -->|Judgment required| judgments["Prepare triage, argument, and form tasks"]
+    judgments --> reduce["Reduce the returned judgments"]
+    reduce --> decision{"SHIP, EDIT, or REBUILD?"}
+    decision -->|SHIP| final
+    decision -->|EDIT| edit
+    decision -->|REBUILD| authorization["Bind a CopySpec and signed authorization"]
+    authorization --> rebuild["Prepare a fingerprint-bound rebuild task"]
+
+    edit --> editor["Human editor or model you choose"]
+    rebuild --> editor
+    editor --> response["Bound response"]
+    response --> candidate["Apply response and produce a candidate"]
+
+    candidate --> mode{"Bound task mode"}
+    draft --> context["Bound original, profile, brief, and supplied evidence"]
+    profile --> context
+    brief --> context
+    evidence["Local sources when supplied; CopySpec for rebuild"] --> context
+    context --> editVerify
+    context --> rebuildVerify
+    mode -->|EDIT| editVerify["Enforce voice, pattern, preservation, logic, Unicode, and supplied evidence gates"]
+    mode -->|REBUILD| rebuildVerify["Enforce voice, pattern, logic, Unicode, CopySpec, and supplied fact gates; report preservation"]
+    editVerify --> passed{"All required gates pass?"}
+    rebuildVerify --> passed
+    passed -->|No| repair["Repair or escalate"]
+    repair --> editor
+    passed -->|Yes| prepareSemantic["Prepare the semantic task and initial lifecycle artifact"]
+    prepareSemantic --> review["Submit authorized, fingerprint-bound semantic verdict(s)"]
+    review --> clearance{"Ready for human review?"}
+    clearance -->|No| escalation["Terminal: needs escalation"]
+    clearance -->|Yes| human{"Human final decision"}
+    human -->|Reject| escalation
+    escalation --> restart["Repair externally and prepare a new fingerprinted task"]
+    restart --> analyze
+    human -->|Approve| approval["Finalize with signed human approval"]
+    approval --> final
+    hygiene -.->|Checked again| final
+    final --> output["Exact accepted text"]
+```
+
+This combines the basic no-change path with the full fingerprint-bound edit and rebuild paths. HYV prepares tasks, validates returned artifacts, and runs deterministic checks locally. It never calls a model: a human editor or model you choose supplies edits and judgments. The basic CLI path below uses `analyze`, `verify`, and `final-check`.
+
 ## install
 
 You need Node.js 20 or newer and at least two writing samples you have the right to use.


### PR DESCRIPTION
## what changed

- add a GitHub Mermaid flowchart for local analysis, bound edit and rebuild tasks, mode-specific deterministic checks, the semantic lifecycle, signed approval, and final output
- state that the caller chooses the human editor or model; HYV makes no model calls

## verification

- npm test: 337/337 passed
- npm run check:release: passed
- HYV hidden-text and final-output checks: passed
- independent clean-code architecture review: PASS