### PR TITLE
fix: support TypeScript 7 and Node 26 typings

### DIFF
--- a/src/profile-watch.ts
+++ b/src/profile-watch.ts
@@ -1,12 +1,14 @@
 import { watch, type FSWatcher } from 'node:fs';
 
+type ProfileWatchTimer = ReturnType<typeof setTimeout>;
+
 export interface ProfileWatchOptions {
   samples: string[];
   debounceMs?: number;
   rebuild: () => void;
   watchFile?: (path: string, listener: () => void) => FSWatcher;
-  schedule?: (callback: () => void, delay: number) => ReturnType<typeof setTimeout>;
-  cancel?: (timer: ReturnType<typeof setTimeout>) => void;
+  schedule?: (callback: () => void, delay: number) => ProfileWatchTimer;
+  cancel?: (timer: ProfileWatchTimer) => void;
 }
 
 export interface ProfileWatchHandle {
@@ -19,9 +21,9 @@ export function watchProfileSamples(options: ProfileWatchOptions): ProfileWatchH
   const debounceMs = options.debounceMs ?? 500;
   if (!Number.isInteger(debounceMs) || debounceMs < 100 || debounceMs > 60_000) throw new Error('Profile watch debounce must be an integer from 100 to 60000 milliseconds.');
   const createWatcher = options.watchFile ?? ((path, listener) => watch(path, { persistent: true }, listener));
-  const schedule = options.schedule ?? setTimeout;
-  const cancel = options.cancel ?? clearTimeout;
-  let timer: ReturnType<typeof setTimeout> | undefined;
+  const schedule: NonNullable<ProfileWatchOptions['schedule']> = options.schedule ?? ((callback, delay) => setTimeout(callback, delay));
+  const cancel: NonNullable<ProfileWatchOptions['cancel']> = options.cancel ?? ((timer) => clearTimeout(timer));
+  let timer: ProfileWatchTimer | undefined;
   let closed = false;
   const trigger = () => {
     if (closed) return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,1 +1,1 @@
-{ "compilerOptions": { "target": "ES2022", "module": "NodeNext", "moduleResolution": "NodeNext", "outDir": "dist", "rootDir": "src", "strict": true, "esModuleInterop": true, "skipLibCheck": true }, "include": ["src/**/*.ts"] }
+{ "compilerOptions": { "target": "ES2022", "module": "NodeNext", "moduleResolution": "NodeNext", "outDir": "dist", "rootDir": "src", "strict": true, "esModuleInterop": true, "skipLibCheck": true, "types": ["node"] }, "include": ["src/**/*.ts"] }


### PR DESCRIPTION
## Summary

- make profile-watch scheduler and canceller use one concrete timer type
- explicitly load Node type declarations for TypeScript 7
- unblock the pending TypeScript 7 and Node 26 Dependabot updates

## Verification

- npm test (380 passing)
- npm run check:release
- git diff --check
- disposable TypeScript 7 + Node 26 compile passed

The full TypeScript 7 + Node 26 test run hit the existing temporary Git mirror test race after compilation; the unchanged test passes on rerun under the current dependency set.