### PR TITLE
fix(ci): skip mirror for Dependabot pushes

### DIFF
--- a/.github/workflows/mirror-to-stitchflow.yml
+++ b/.github/workflows/mirror-to-stitchflow.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   mirror:
-    if: github.repository == 'shashank-sn/holdyourvoice'
+    if: github.repository == 'shashank-sn/holdyourvoice' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/scripts/release-audit.mjs
+++ b/scripts/release-audit.mjs
@@ -80,7 +80,7 @@ const mirrorRequirements = [
   [mirrorWorkflow, /^  workflow_dispatch:\s*$/m, 'mirror workflow must support manual recovery'],
   [mirrorWorkflow, /^  schedule:\n    - cron: ["']17 3 \* \* \*["']$/m, 'mirror workflow must reconcile refs on a schedule'],
   [mirrorWorkflow, /^concurrency:\n  group: mirror-to-stitchflow\n  cancel-in-progress: false$/m, 'mirror workflow must serialize full-ref updates and finish the active update'],
-  [mirrorWorkflow, /^  mirror:\n    if: github\.repository == 'shashank-sn\/holdyourvoice'\n    runs-on: ubuntu-latest\n    timeout-minutes: 10$/m, 'mirror workflow must run only in the public source repository with a bounded timeout'],
+  [mirrorWorkflow, /^  mirror:\n    if: github\.repository == 'shashank-sn\/holdyourvoice' && github\.actor != 'dependabot\[bot\]'\n    runs-on: ubuntu-latest\n    timeout-minutes: 10$/m, 'mirror workflow must run only in the public source outside Dependabot pushes with a bounded timeout'],
   [mirrorWorkflow, /^      - uses: actions\/checkout@v7$/m, 'mirror workflow must use the current checkout action'],
   [mirrorWorkflow, /^ {10}if \[ -z "\$\{MIRROR_DEPLOY_KEY:-\}" \]; then$/m, 'mirror workflow must validate the source deploy key'],
   [mirrorWorkflow, /^ {10}node scripts\/mirror-refs\.mjs$/m, 'mirror workflow must run the tested ref reconciler'],

--- a/src/release-audit.test.ts
+++ b/src/release-audit.test.ts
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   mirror:
-    if: github.repository == 'shashank-sn/holdyourvoice'
+    if: github.repository == 'shashank-sn/holdyourvoice' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -96,15 +96,29 @@ test('accepts the complete public package contract', () => {
   }
 });
 
-test('requires the mirror workflow to run only in the public source repository', () => {
+test('requires the mirror workflow to run only in the public source repository outside Dependabot pushes', () => {
   const directory = fixture({
     'README.md': '# public',
-    '.github/workflows/mirror-to-stitchflow.yml': mirrorWorkflow.replace("    if: github.repository == 'shashank-sn/holdyourvoice'\n", ''),
+    '.github/workflows/mirror-to-stitchflow.yml': mirrorWorkflow.replace("    if: github.repository == 'shashank-sn/holdyourvoice' && github.actor != 'dependabot[bot]'\n", ''),
   });
   try {
     const result = spawnSync(process.execPath, [audit], { cwd: directory, encoding: 'utf8' });
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /mirror workflow must run only in the public source repository with a bounded timeout/);
+    assert.match(result.stderr, /mirror workflow must run only in the public source outside Dependabot pushes with a bounded timeout/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('requires the mirror workflow to exclude Dependabot pushes', () => {
+  const directory = fixture({
+    'README.md': '# public',
+    '.github/workflows/mirror-to-stitchflow.yml': mirrorWorkflow.replace(" && github.actor != 'dependabot[bot]'", ''),
+  });
+  try {
+    const result = spawnSync(process.execPath, [audit], { cwd: directory, encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /mirror workflow must run only in the public source outside Dependabot pushes with a bounded timeout/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -116,7 +130,7 @@ for (const requirement of [
   { name: 'scheduled reconciliation', fragment: "  schedule:\n    - cron: '17 3 \* \* \*'\n", error: /mirror workflow must reconcile refs on a schedule/ },
   { name: 'serialized updates', fragment: '  group: mirror-to-stitchflow\n', error: /mirror workflow must serialize full-ref updates and finish the active update/ },
   { name: 'non-cancelled active updates', fragment: '  cancel-in-progress: false\n', error: /mirror workflow must serialize full-ref updates and finish the active update/ },
-  { name: 'bounded execution', fragment: '    timeout-minutes: 10\n', error: /mirror workflow must run only in the public source repository with a bounded timeout/ },
+  { name: 'bounded execution', fragment: '    timeout-minutes: 10\n', error: /mirror workflow must run only in the public source outside Dependabot pushes with a bounded timeout/ },
   { name: 'current checkout action', fragment: '      - uses: actions/checkout@v7\n', error: /mirror workflow must use the current checkout action/ },
   { name: 'deploy-key validation', fragment: '          if [ -z "${MIRROR_DEPLOY_KEY:-}" ]; then\n', error: /mirror workflow must validate the source deploy key/ },
   { name: 'tested reconciliation', fragment: '          node scripts/mirror-refs.mjs\n', error: /mirror workflow must run the tested ref reconciler/ },


### PR DESCRIPTION
## Summary
- Skip the Stitchflow mirror job for `dependabot[bot]` pushes, where GitHub withholds repository secrets.
- Preserve the existing repository, event, deploy-key, and destination guards for eligible mirror runs.
- Extend the release-audit contract test to lock the exclusion in place.

## Root cause
The failed mirror run was triggered by Dependabot. GitHub does not provide repository secrets to that event, so the existing deploy-key check correctly failed before the mirror could run.

## Verification
- `npm test` — 415 passing
- `npm run check:release` — passing
- `npm run pack:claude` — passing
- `git diff --check` and YAML parse — passing
- `clean-code verify --allow-repository-policy --output .context/clean-verify-7be2f4e .` — passing on `7be2f4e`
- Independent test planning and code review — no gaps or findings
- Clean audit receipt — complete; the GitHub Actions run is the remaining runtime proof

No issue link: this resolves the observed Dependabot CI failure.