### PR TITLE
docs: sharpen plugin directory copy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "hold-your-voice",
       "source": "./claude-plugin",
       "description": "Keep a writer's voice while using Claude.",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "author": {
         "name": "Shashank SN"
       }

--- a/chatgpt-plugin/.codex-plugin/plugin.json
+++ b/chatgpt-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hold-your-voice",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A careful writing-review workflow for protecting voice and removing generic AI patterns.",
   "author": {
     "name": "Shashank SN",
@@ -13,8 +13,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Hold Your Voice",
-    "shortDescription": "Review and revise writing without sanding off its voice.",
-    "longDescription": "A deliberate writing-review workflow for spotting generic AI patterns, protecting stated constraints, and revising only the text that needs work. It gives editorial guidance in ChatGPT; it does not run the local HYV CLI or claim deterministic VoiceDNA results.",
+    "shortDescription": "Make AI writing sound like you.",
+    "longDescription": "Hold Your Voice helps you revise drafts without flattening the way you write. Share a draft and a few examples of your voice; it flags generic phrasing, protects your constraints, and improves only what needs changing.",
     "developerName": "Shashank SN",
     "category": "Productivity",
     "capabilities": [],

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "hold-your-voice",
   "displayName": "Hold Your Voice",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A local-first writing gate for VoiceDNA, AI-editor patterns, and Unicode hygiene.",
   "author": {
     "name": "Shashank SN",

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "hold-your-voice": {
       "command": "npm",
-      "args": ["exec", "--yes", "--package=@holdyourvoice/hyv@4.0.1", "--", "hyv", "mcp"]
+      "args": ["exec", "--yes", "--package=@holdyourvoice/hyv@4.0.2", "--", "hyv", "mcp"]
     }
   }
 }

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "hold-your-voice",
   "display_name": "Hold Your Voice",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Keep your writing voice when you use Claude.",
   "long_description": "A fully local writing gate for Claude Desktop. Run a profile-free final-output check on text from any source, build a VoiceDNA profile from your own samples, inspect a draft with separate VoiceDNA and AI Editor checks plus non-scoring Unicode hygiene, create a constrained editing brief, and verify a revised candidate. Clean final output passes through unchanged; only a leading byte-order mark is removed automatically, while unresolved hidden Unicode is withheld for review. Verification is read-only. Explicit or separately approved learning stores no drafts or samples and makes no network requests.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holdyourvoice/hyv",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Local writing checks, voice profiles, and verified editing workflows for humans and agents.",
   "type": "module",
   "bin": {

--- a/src/rebuild-task.test.ts
+++ b/src/rebuild-task.test.ts
@@ -191,7 +191,7 @@ test('CLI and MCP rebuild helpers share fingerprints', () => {
     version: '1', audience: 'operators', intent: 'explain', format: 'outreach',
   });
   assert.match(briefTask.prompt, /# WritingBrief/);
-  assert.equal(HYV_VERSION, '4.0.1');
+  assert.equal(HYV_VERSION, '4.0.2');
 });
 
 test('apply rejects forged tasks, missing capability, and substituted profiles', () => {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const HYV_VERSION = '4.0.1';
+export const HYV_VERSION = '4.0.2';


### PR DESCRIPTION
Updates the ChatGPT/Codex Plugin Directory copy for v4.0.2.\n\n- focus the listing on the writing outcome\n- remove internal CLI and VoiceDNA caveats\n- keep the repository and plugin manifest versions aligned